### PR TITLE
feat: project 게시글 삭제 api 추가

### DIFF
--- a/src/entities/projects/api/projectsAPi.ts
+++ b/src/entities/projects/api/projectsAPi.ts
@@ -8,6 +8,8 @@ import {
   QueryDocumentSnapshot,
   startAfter,
   type DocumentData,
+  doc,
+  getDoc,
 } from "firebase/firestore";
 
 import type { ProjectListRes } from "@entities/projects/types/projects";
@@ -59,5 +61,24 @@ export const getProjectList = async ({
   } catch (err) {
     console.log(err);
     return { projects: [], lastVisible: null };
+  }
+};
+
+/** firebase project item 상세 조회 */
+export const getProjectItem = async (
+  id: string
+): Promise<ProjectListRes | null> => {
+  try {
+    const docRef = doc(db, "projects", id);
+    const docSnap = await getDoc(docRef);
+
+    if (!docSnap.exists()) {
+      return null;
+    }
+
+    return docSnap.data() as ProjectListRes;
+  } catch (err) {
+    console.log(err);
+    return null;
   }
 };

--- a/src/entities/projects/queries/useProjectsItem.ts
+++ b/src/entities/projects/queries/useProjectsItem.ts
@@ -1,0 +1,21 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+
+import { getProjectItem } from "@entities/projects/api/projectsAPi";
+import type { ProjectListRes } from "@entities/projects/types/projects";
+
+const useProjectsItem = ({
+  id,
+}: {
+  id: string | null;
+}): UseQueryResult<ProjectListRes | null, Error> => {
+  return useQuery({
+    queryKey: ["projects-total-count"],
+    queryFn: () => {
+      if (!id) return null;
+      return getProjectItem(id);
+    },
+    enabled: !!id,
+  });
+};
+
+export default useProjectsItem;

--- a/src/entities/projects/types/firebase.ts
+++ b/src/entities/projects/types/firebase.ts
@@ -6,3 +6,9 @@ import type {
 
 export type CreatedAt = Timestamp;
 export type LastVisibleType = (QueryDocumentSnapshot<DocumentData> | null)[];
+
+export interface ApiResMessage {
+  success: boolean;
+  message: string;
+  id?: string;
+}

--- a/src/features/projects/api/projdectsApi.ts
+++ b/src/features/projects/api/projdectsApi.ts
@@ -4,8 +4,10 @@ import {
   doc,
   serverTimestamp,
   setDoc,
-} from "firebase/firestore/lite";
+  deleteDoc,
+} from "firebase/firestore";
 
+import type { ApiResMessage } from "@entities/projects/types/firebase";
 import type { ProjectItemInsertReq } from "@entities/projects/types/projects";
 
 import { db } from "@shared/firebase/firebase";
@@ -13,7 +15,7 @@ import { db } from "@shared/firebase/firebase";
 /** firebase projects에 item 등록 */
 export const insertProjectItem = async (
   projectItem: ProjectItemInsertReq
-): Promise<{ success: boolean; message: string; id?: string }> => {
+): Promise<ApiResMessage> => {
   try {
     const postsRef = collection(db, "projects");
     const docRef = await addDoc(postsRef, {
@@ -35,7 +37,30 @@ export const insertProjectItem = async (
   }
 };
 
-/** firebase projects에 item 수정 */
+/** firebase projectsItem 삭제 */
+export const deleteProjectItem = async (id: string): Promise<ApiResMessage> => {
+  if (!window.confirm("정말로 삭제하시겠습니까?")) {
+    return { success: false, message: "" };
+  }
+
+  try {
+    const docRef = doc(db, "projects", id);
+    await deleteDoc(docRef);
+
+    return {
+      success: true,
+      message: "프로젝트를 정상적으로 삭제하였습니다.",
+    };
+  } catch (err) {
+    console.log(err);
+    return {
+      success: false,
+      message: "프로젝트 삭제에 실패하였습니다.",
+    };
+  }
+};
+
+/** firebase projectsItem 수정 */
 export const updateProjectItem = async (): Promise<void> => {
   return;
   const docRef = doc(db, "coments", "test");

--- a/src/features/projects/queries/useProjectDelete.ts
+++ b/src/features/projects/queries/useProjectDelete.ts
@@ -1,0 +1,33 @@
+import { useMutation, type UseMutationResult } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
+
+import { deleteProjectItem } from "@features/projects/api/projdectsApi";
+
+import type { ApiResMessage } from "@entities/projects/types/firebase";
+
+const useProjectDelete = (): UseMutationResult<
+  ApiResMessage,
+  Error,
+  string
+> => {
+  const Navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: (id: string) => {
+      return deleteProjectItem(id);
+    },
+    onSuccess: (data) => {
+      if (data.message) {
+        alert(data.message);
+      }
+      if (data.success) {
+        Navigate("/");
+      }
+    },
+    onError: (err) => {
+      alert("정상적으로 삭제되지 않았습니다.");
+      console.log(err);
+    },
+  });
+};
+export default useProjectDelete;

--- a/src/pages/project-detail/ui/ProjectDetailPage.tsx
+++ b/src/pages/project-detail/ui/ProjectDetailPage.tsx
@@ -1,16 +1,43 @@
 import type { JSX } from "react";
+import { useParams } from "react-router-dom";
+
+import useProjectDelete from "@features/projects/queries/useProjectDelete";
+
+import useProjectsItem from "@entities/projects/queries/useProjectsItem";
 
 const ProjectDetailPage = (): JSX.Element => {
+  const { id } = useParams();
+  const {
+    data: info,
+    isLoading,
+    isError,
+  } = useProjectsItem({ id: id || null });
+  const { mutate: deleteProject } = useProjectDelete();
+
+  const hadleDeleteProject = (): void => {
+    if (!id) return;
+    deleteProject(id);
+  };
+
+  if (isLoading) {
+    return <div>로딩중</div>;
+  }
+  if (!info || isError) {
+    return <div>404</div>;
+  }
   return (
     <div>
       <h1>프로젝트 상세 페이지</h1>
       <p>프로젝트의 상세 정보를 확인할 수 있습니다.</p>
+
+      <button onClick={hadleDeleteProject}> 삭제</button>
       <div>
         <h2>프로젝트 정보</h2>
         <ul>
-          <li>이름: Sample Project</li>
-          <li>기술 스택: React, TypeScript, React Router</li>
-          <li>아키텍처: Feature-Sliced Design</li>
+          <li>id: {id}</li>
+          <li>이름: {info.title}</li>
+          <li>기술 스택: {info.techStack.join(", ")}</li>
+          <li>우대사항: {info.preferentialTreatment}</li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
## 개요
이 PR의 목적과 구현 내용을 간단히 설명합니다.

## 변경 사항
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 구현 내용
- deleteProjectItem 추가
   - Firestore Lite ->  firestore 변경

## 개발 후기 및 개선사항
### 이번 작업에서 배운 점
- useQuery와 useMutation의 쓰임새 구분 (R / CUD)

### 어려웠던 점 / 에로사항
- (없다면 패스)

### 다음에 개선하고 싶은 점
- (없다면 패스)

### 팀원들과 공유하고 싶은 팁
- (없다면 패스) 