### PR TITLE
Feat/firebase/czmcm5

### DIFF
--- a/src/features/projects/queries/useProjectDelete.ts
+++ b/src/features/projects/queries/useProjectDelete.ts
@@ -7,20 +7,25 @@ import type { ApiResMessage } from "@entities/projects/types/firebase";
 
 import { useAuthStore } from "@shared/stores/authStore";
 
+interface IDsType {
+  postID: string;
+  projectOwnerID: string;
+}
+
 const useProjectDelete = (): UseMutationResult<
   ApiResMessage,
   Error,
-  string
+  IDsType
 > => {
   const Navigate = useNavigate();
   const user = useAuthStore((state) => state.user);
 
   return useMutation({
-    mutationFn: (id: string) => {
-      if (user?.uid !== id) {
+    mutationFn: ({ postID, projectOwnerID }: IDsType) => {
+      if (user?.uid !== projectOwnerID) {
         throw new Error("삭제 권한이 없습니다.");
       }
-      return deleteProjectItem(id);
+      return deleteProjectItem(postID);
     },
     onSuccess: (data) => {
       if (data.message) {

--- a/src/features/projects/queries/useProjectDelete.ts
+++ b/src/features/projects/queries/useProjectDelete.ts
@@ -5,27 +5,34 @@ import { deleteProjectItem } from "@features/projects/api/projectsApi";
 
 import type { ApiResMessage } from "@entities/projects/types/firebase";
 
+import { useAuthStore } from "@shared/stores/authStore";
+
 const useProjectDelete = (): UseMutationResult<
   ApiResMessage,
   Error,
   string
 > => {
   const Navigate = useNavigate();
+  const user = useAuthStore((state) => state.user);
 
   return useMutation({
     mutationFn: (id: string) => {
+      if (user?.uid !== id) {
+        throw new Error("삭제 권한이 없습니다.");
+      }
       return deleteProjectItem(id);
     },
     onSuccess: (data) => {
       if (data.message) {
         alert(data.message);
       }
+      // 게시글 삭제 후 목록페이지로 이동
       if (data.success) {
-        Navigate("/");
+        Navigate("/project");
       }
     },
     onError: (err) => {
-      alert("정상적으로 삭제되지 않았습니다.");
+      alert(err || "정상적으로 삭제되지 않았습니다.");
       console.log(err);
     },
   });

--- a/src/features/projects/ui/ProjectDelete.tsx
+++ b/src/features/projects/ui/ProjectDelete.tsx
@@ -1,0 +1,41 @@
+import { Box, styled, Typography } from "@mui/material";
+import type { JSX } from "react";
+import { useParams } from "react-router-dom";
+
+import useProjectDelete from "@features/projects/queries/useProjectDelete";
+
+const ProjectDelete = (): JSX.Element => {
+  const { id } = useParams();
+  const { mutate: projectdelete, isPending } = useProjectDelete();
+
+  const handleDeleteBtn = (): void => {
+    if (id && !isPending) {
+      projectdelete(id);
+    }
+  };
+
+  return (
+    <MessageBtn onClick={handleDeleteBtn}>
+      <Typography>삭제</Typography>
+    </MessageBtn>
+  );
+};
+
+export default ProjectDelete;
+
+const MessageBtn = styled(Box)`
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 4rem;
+  border-radius: 4px;
+  color: white;
+  background-color: tomato;
+  transition: background-color 0.3s ease;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #e14b30;
+  }
+`;

--- a/src/features/projects/ui/ProjectDelete.tsx
+++ b/src/features/projects/ui/ProjectDelete.tsx
@@ -4,13 +4,17 @@ import { useParams } from "react-router-dom";
 
 import useProjectDelete from "@features/projects/queries/useProjectDelete";
 
-const ProjectDelete = (): JSX.Element => {
-  const { id } = useParams();
+const ProjectDelete = ({
+  projectOwnerID,
+}: {
+  projectOwnerID: string;
+}): JSX.Element => {
+  const { id: postID } = useParams();
   const { mutate: projectdelete, isPending } = useProjectDelete();
 
   const handleDeleteBtn = (): void => {
-    if (id && !isPending) {
-      projectdelete(id);
+    if (postID && !isPending) {
+      projectdelete({ postID, projectOwnerID });
     }
   };
 

--- a/src/pages/project-detail/ui/ProjectDetailPage.tsx
+++ b/src/pages/project-detail/ui/ProjectDetailPage.tsx
@@ -3,6 +3,7 @@ import { type JSX } from "react";
 import { useParams } from "react-router-dom";
 
 import ProjectApplyForm from "@features/projects/ui/ProjectApplyForm";
+import ProjectDelete from "@features/projects/ui/ProjectDelete";
 
 import useProjectsItem from "@entities/projects/queries/useProjectsItem";
 import ProjectApply from "@entities/projects/ui/post-info/ProjectApply";
@@ -16,8 +17,11 @@ import ProjectRequirements from "@entities/projects/ui/projects-detail/ProjectRe
 import ProjectSchedule from "@entities/projects/ui/projects-detail/ProjectSchedule";
 import TechStack from "@entities/projects/ui/projects-detail/TechStack";
 
+import { useAuthStore } from "@shared/stores/authStore";
+
 const ProjectDetailPage = (): JSX.Element => {
   const { id } = useParams();
+  const user = useAuthStore((state) => state.user);
   const {
     data: project,
     isLoading,
@@ -104,7 +108,11 @@ const ProjectDetailPage = (): JSX.Element => {
           </CardBox>
           <CardBox>
             <ProjectApply applicants={project.applicants.length} />
-            <ProjectApplyForm />
+            {user?.uid === project.projectOwner.id ? (
+              <ProjectDelete />
+            ) : (
+              <ProjectApplyForm />
+            )}
           </CardBox>
           <CardBox>
             <ProjectPostInfo values={postInfoValues} />

--- a/src/pages/project-detail/ui/ProjectDetailPage.tsx
+++ b/src/pages/project-detail/ui/ProjectDetailPage.tsx
@@ -109,7 +109,7 @@ const ProjectDetailPage = (): JSX.Element => {
           <CardBox>
             <ProjectApply applicants={project.applicants.length} />
             {user?.uid === project.projectOwner.id ? (
-              <ProjectDelete />
+              <ProjectDelete projectOwnerID={project?.projectOwner.id} />
             ) : (
               <ProjectApplyForm />
             )}


### PR DESCRIPTION
## 개요
로그인 상태로 상세 페이지 접근 시, 게시글 작성자라면 지원하기 버튼을 숨기고 게시글 삭제버튼이 보이도록 수정하였습니다.

## 변경 사항
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 구현 내용
- 상세 페이지에 게시글 삭제 버튼 추가
   - 로그인 상태에서 로그인한 사용자의 uid와 게시글 작성자 idf를 비교하여 올바르시 삭제
   - 작성자가 아니면 삭제버튼이 보이지 않으먀, 작성자 일 시, 지원하기 버튼이 보이지 않습니다.

## 개발 후기 및 개선사항
### 이번 작업에서 배운 점
- useMutation의 함수의 인자를 넘겨줄 때, 무조건 하나의 인자만 받게 되어잇엇다는 것을 처 ,,음 알앗습니다 .. 😅

### 어려웠던 점 / 에로사항
- uid 검사식을 어디에 둘지 고민하다가 로직의 일관성을 위해 useMutation을 실행하는 훅에서 진행하도록 하였습니다. 책임 분리는 어렵네욥

### 다음에 개선하고 싶은 점
- 카드식으로 나누다 보니 ProjectDetailPage.tsx 에서 전달해야할 props가 많고, 로그인 여부에 따라 보이는 view가 달라야해서 검사식을 넣느라 좀 난잡해진 느낌이 있는데 컴포넌트를 한단계 더 묶어서 분리하는편이 좋을까? 아니면 굳이일까... 고민이 됩니다 🥹

### 팀원들과 공유하고 싶은 팁
- 위 개선점에 대해 피드백이 있다면 코멘트 달아주시면 감사하겠습니다 (_  _)