### PR TITLE
지원하기 api 추가

### DIFF
--- a/src/entities/projects/queries/useProjectsItem.ts
+++ b/src/entities/projects/queries/useProjectsItem.ts
@@ -10,7 +10,7 @@ const useProjectsItem = ({
   id: string | null;
 }): UseQueryResult<ProjectListRes | null, Error> => {
   return useQuery({
-    queryKey: ["projects-total-count"],
+    queryKey: ["project-detail", id],
     queryFn: () => {
       if (!id) return null;
       return getProjectItem(id);

--- a/src/features/projects/api/projectsApi.ts
+++ b/src/features/projects/api/projectsApi.ts
@@ -4,6 +4,8 @@ import {
   doc,
   serverTimestamp,
   deleteDoc,
+  updateDoc,
+  arrayUnion,
 } from "firebase/firestore";
 
 import type { ApiResMessage } from "@entities/projects/types/firebase";
@@ -59,7 +61,43 @@ export const deleteProjectItem = async (id: string): Promise<ApiResMessage> => {
   }
 };
 
-/** firebase projectsItem 수정 */
+/** firebase projectsItem(게시글) 수정 */
 export const updateProjectItem = async (): Promise<void> => {
   return;
+};
+
+/** 프로젝트 지원하기
+ * projects - applicants에 uid 넣기
+ * user - appliedProjects에 projectID 넣기
+ */
+export const updateProjectApply = async (
+  uid: string,
+  projectID: string
+): Promise<ApiResMessage> => {
+  console.log({ uid, projectID });
+
+  const projecstRef = doc(db, "projects", projectID);
+  const usersRef = doc(db, "users", uid);
+
+  try {
+    const updateProject = updateDoc(projecstRef, {
+      applicants: arrayUnion(uid),
+    });
+    const updateUser = updateDoc(usersRef, {
+      appliedProjects: arrayUnion(projectID),
+    });
+
+    await Promise.all([updateProject, updateUser]);
+
+    return {
+      success: true,
+      message: "프로젝트에 지원이 완료되었습니다. 행운을 빌어요 🚀",
+    };
+  } catch (err) {
+    console.log(err);
+    return {
+      success: false,
+      message: "프로젝트 지원에 실패하였습니다.",
+    };
+  }
 };

--- a/src/features/projects/hook/useApplyFrom.tsx
+++ b/src/features/projects/hook/useApplyFrom.tsx
@@ -1,5 +1,7 @@
 import { useState, type ChangeEvent } from "react";
 
+import useProjectApply from "@features/projects/queries/useProjectApply";
+
 interface ApplyFormResult {
   openForm: {
     isOpen: boolean;
@@ -13,7 +15,9 @@ interface ApplyFormResult {
   submit: () => void;
 }
 
-const useApplyFrom = (): ApplyFormResult => {
+const useApplyFrom = (projectID: string): ApplyFormResult => {
+  const { mutate: updateApply } = useProjectApply();
+
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [applyMessage, setApplyMessage] = useState("");
 
@@ -24,11 +28,12 @@ const useApplyFrom = (): ApplyFormResult => {
     setApplyMessage(e.target.value);
 
   const submit = (): void => {
+    if (!projectID) return;
     if (!applyMessage.trim()) {
       alert("메세지를 적어주세요");
       return;
     }
-    alert("api가 없어요");
+    updateApply(projectID);
   };
 
   return {

--- a/src/features/projects/queries/useProjectApply.ts
+++ b/src/features/projects/queries/useProjectApply.ts
@@ -22,7 +22,7 @@ const useProjectApply = (): UseMutationResult<ApiResMessage, Error, string> => {
       // 지원 완료 후 프로필로 이동
       alert(data.message);
       if (data.success) {
-        Navigate(`/project/${data.id}`);
+        Navigate("/profile");
       }
     },
     onError: (err) => {

--- a/src/features/projects/queries/useProjectApply.ts
+++ b/src/features/projects/queries/useProjectApply.ts
@@ -1,0 +1,34 @@
+import { useMutation, type UseMutationResult } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
+
+import { updateProjectApply } from "@features/projects/api/projectsApi";
+
+import type { ApiResMessage } from "@entities/projects/types/firebase";
+
+import { useAuthStore } from "@shared/stores/authStore";
+
+const useProjectApply = (): UseMutationResult<ApiResMessage, Error, string> => {
+  const Navigate = useNavigate();
+  const user = useAuthStore((state) => state.user);
+
+  return useMutation({
+    mutationFn: (projectID: string) => {
+      if (!user) {
+        throw new Error("로그인을 해주세요.");
+      }
+      return updateProjectApply(user.uid, projectID);
+    },
+    onSuccess: (data) => {
+      // 지원 완료 후 프로필로 이동
+      alert(data.message);
+      if (data.success) {
+        Navigate(`/project/${data.id}`);
+      }
+    },
+    onError: (err) => {
+      alert(err);
+      console.log(err);
+    },
+  });
+};
+export default useProjectApply;

--- a/src/features/projects/ui/ProjectApplyForm.tsx
+++ b/src/features/projects/ui/ProjectApplyForm.tsx
@@ -1,11 +1,28 @@
 import RocketLaunchIcon from "@mui/icons-material/RocketLaunch";
 import { Box, styled, Typography } from "@mui/material";
 import type { JSX } from "react";
+import { useParams } from "react-router-dom";
 
 import useApplyFrom from "@features/projects/hook/useApplyFrom";
 
-const ProjectApplyForm = (): JSX.Element => {
-  const { openForm, message, submit } = useApplyFrom();
+import { useAuthStore } from "@shared/stores/authStore";
+
+const ProjectApplyForm = ({
+  applicants,
+}: {
+  applicants: string[];
+}): JSX.Element => {
+  const { id } = useParams();
+  const user = useAuthStore((state) => state.user);
+  const { openForm, message, submit } = useApplyFrom(id || "");
+
+  if (user && applicants.includes(user?.uid || "")) {
+    return (
+      <MessageBtn className="done">
+        <Typography>지원완료</Typography>
+      </MessageBtn>
+    );
+  }
 
   /* 지원하기 폼 닫혀있을 때 */
   if (!openForm.isOpen) {
@@ -84,5 +101,11 @@ const MessageBtn = styled(Box)`
     &:hover {
       background: linear-gradient(to bottom right, #474dc0, #7324bd);
     }
+  }
+
+  &.done {
+    cursor: default;
+    color: #858585;
+    background-color: #f0f0f0;
   }
 `;

--- a/src/pages/project-detail/ui/ProjectDetailPage.tsx
+++ b/src/pages/project-detail/ui/ProjectDetailPage.tsx
@@ -111,7 +111,7 @@ const ProjectDetailPage = (): JSX.Element => {
             {user?.uid === project.projectOwner.id ? (
               <ProjectDelete projectOwnerID={project?.projectOwner.id} />
             ) : (
-              <ProjectApplyForm />
+              <ProjectApplyForm applicants={project?.applicants || []} />
             )}
           </CardBox>
           <CardBox>


### PR DESCRIPTION
## 개요
상세 조회 페이지에서 유저는 지원하기 버튼을 통해 프로젝트에 지원할 수 있도록 기능을 추가하였습니다.

## 변경 사항
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정

## 구현 내용
- 프로젝트 지원하기 기능 추가
  - 각 db 컬렉션에 projects - applicants에 uid / user - appliedProjects에 projectID 가 넣어지도록 하였습니다.
- 내가 지원한 프로젝트의 경우 지원하기 버튼이 지원완료 버튼으로 바뀝니다.

## 개발 후기 및 개선사항
### 이번 작업에서 배운 점
- Zustand의 특성
   - 로그인 여부나 로그인한 유저의 id를 여러 컴포넌트에서 사용하기에 어디서 어떻게 호출하여 알맞은 곳에 넣어줄 수 있을지 고민했는데 Zustand 특성상 selector을 여러 곳에서 호출해도 성능상 문제가 없도록 만들어졌다는 것을 알게된 후 각 컴포넌트의 의존성을 최소화 하기 위해 필요한 컴포넌트마다 호출하기로 하였습니다.
- react-Query문 의 호출 위치
   - 지원하기 버튼이 동작을 수행할 때 내부 필드(message)의 유효성 검사도 하고 비동기 함수 호출도 해야해서 어디서 어떻게 호출하는 것이 알맞을까 고민한 결과 마찬가지로 컴포넌트의 의존성을 줄이고 비지니스 로직들은 한곳에서 관리하기 위해 submit을 수행하는 훅에서 query문을 수행할 수 있도록 하였습니다.

### 어려웠던 점 / 에로사항
- 책임 분리는 어려운거 같습니다ㅏㅏ...

### 다음에 개선하고 싶은 점
- 생각해보니 테스트 코드를 전혀 작성하지 못하고 있어 프로젝트가 완료된 후에라도 수행하고싶네요!

### 팀원들과 공유하고 싶은 팁
- (없다면 패스) 