### PR TITLE
feat: 프로젝트 상세 좋아요, 좋아요 취소 기능 추가

### DIFF
--- a/src/entities/projects/queries/useProjectsItem.ts
+++ b/src/entities/projects/queries/useProjectsItem.ts
@@ -5,7 +5,7 @@ import { getProjectItem } from "@entities/projects/api/projectsAPi";
 import type { ProjectListRes } from "@shared/types/project";
 
 const useProjectsItem = ({
-  id,
+  id, // projectID
 }: {
   id: string | null;
 }): UseQueryResult<ProjectListRes | null, Error> => {

--- a/src/entities/projects/ui/projects-detail/ProjectInfo.tsx
+++ b/src/entities/projects/ui/projects-detail/ProjectInfo.tsx
@@ -1,23 +1,17 @@
 import AccessTimeOutlinedIcon from "@mui/icons-material/AccessTimeOutlined";
 import CalendarTodayOutlinedIcon from "@mui/icons-material/CalendarTodayOutlined";
-import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
 import GroupIcon from "@mui/icons-material/Group";
 import RoomOutlinedIcon from "@mui/icons-material/RoomOutlined";
-import ShareIcon from "@mui/icons-material/Share";
 import { Box, styled, Typography } from "@mui/material";
 import type { JSX } from "react";
 
-import {
-  formatDate,
-  getStatusClassname,
-} from "@shared/libs/utils/projectDetail";
+import { formatDate } from "@shared/libs/utils/projectDetail";
 import type { ProjectListRes } from "@shared/types/project";
 import InfoWithIcon from "@shared/ui/project-detail/InfoWithIcon";
 
 type ProjectInfoType = Pick<
   ProjectListRes,
   | "title"
-  | "status"
   | "teamSize"
   | "workflow"
   | "simpleInfo"
@@ -35,21 +29,6 @@ const ProjectInfo = ({
 
   return (
     <>
-      <Box display="flex" alignItems="center" justifyContent="space-between">
-        <StatusBox className={getStatusClassname(values.status)}>
-          {values.status}
-        </StatusBox>
-
-        <Box display="flex">
-          <HeadIconBox>
-            <FavoriteBorderIcon />
-          </HeadIconBox>
-          <HeadIconBox>
-            <ShareIcon />
-          </HeadIconBox>
-        </Box>
-      </Box>
-
       <Typography variant="h2">{values.title}</Typography>
       <OneLineInfo>{values.oneLineInfo}</OneLineInfo>
       <Typography>{values.simpleInfo}</Typography>
@@ -81,40 +60,6 @@ const ProjectInfo = ({
 };
 
 export default ProjectInfo;
-
-const HeadIconBox = styled(Box)`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 3.5rem;
-  height: 3rem;
-  padding: 0.5rem 1rem;
-  margin-left: 10px;
-  border: 1px solid #dddddd;
-  border-radius: 4px;
-  transition: background-color 0.3s;
-  cursor: pointer;
-
-  &:hover {
-    background-color: #f4f4f4;
-  }
-`;
-
-const StatusBox = styled("div")`
-  padding: 0.5rem 1.2rem;
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 0.025em;
-  color: white;
-  border-radius: 50px;
-
-  &.ing {
-    background-color: black;
-  }
-  &.done {
-    background-color: ${({ theme }) => theme.palette.primary.main};
-  }
-`;
 
 const OneLineInfo = styled("div")`
   margin: 1rem 0 1.5rem 0;

--- a/src/features/projects/hook/useLike.tsx
+++ b/src/features/projects/hook/useLike.tsx
@@ -1,0 +1,55 @@
+import { useState } from "react";
+
+import useProjectLike from "@features/projects/queries/useProjectLike";
+import useProjectUnLike from "@features/projects/queries/useProjectUnLike";
+
+import { useAuthStore } from "@shared/stores/authStore";
+
+interface LikeResult {
+  isLike: boolean;
+  like: () => void;
+  unlike: () => void;
+}
+
+const useLike = ({
+  projectID,
+  likedUsers,
+}: {
+  projectID: string;
+  likedUsers: string[];
+}): LikeResult => {
+  const user = useAuthStore((state) => state.user);
+  const { mutate: updateLike, isPending: likePending } = useProjectLike();
+  const { mutate: updateUnLike, isPending: unLikePending } = useProjectUnLike();
+
+  const initLike = user && likedUsers.includes(user.uid);
+  const [isLike, setIsLike] = useState(initLike || false);
+
+  const like = (): void => {
+    if (!projectID) return;
+    if (likePending || unLikePending) {
+      alert("동작이 너무 빠릅니다. 잠시 후에 시도해주십시오.");
+      return;
+    }
+    setIsLike(true);
+    updateLike(projectID);
+  };
+
+  const unlike = (): void => {
+    if (!projectID) return;
+    if (likePending || unLikePending) {
+      alert("동작이 너무 빠릅니다. 잠시 후에 시도해주십시오.");
+      return;
+    }
+    setIsLike(false);
+    updateUnLike(projectID);
+  };
+
+  return {
+    isLike,
+    like,
+    unlike,
+  };
+};
+
+export default useLike;

--- a/src/features/projects/queries/useProjectLike.ts
+++ b/src/features/projects/queries/useProjectLike.ts
@@ -1,14 +1,13 @@
 import { useMutation, type UseMutationResult } from "@tanstack/react-query";
-import { useNavigate } from "react-router-dom";
 
 import { updateApplyOrLike } from "@features/projects/api/projectsApi";
 
 import type { ApiResMessage } from "@entities/projects/types/firebase";
 
+import queryClient from "@shared/react-query/queryClient";
 import { useAuthStore } from "@shared/stores/authStore";
 
-const useProjectApply = (): UseMutationResult<ApiResMessage, Error, string> => {
-  const Navigate = useNavigate();
+const useProjectLike = (): UseMutationResult<ApiResMessage, Error, string> => {
   const user = useAuthStore((state) => state.user);
 
   return useMutation({
@@ -16,13 +15,14 @@ const useProjectApply = (): UseMutationResult<ApiResMessage, Error, string> => {
       if (!user) {
         throw new Error("로그인을 해주세요.");
       }
-      return updateApplyOrLike(user.uid, projectID, "apply");
+      return updateApplyOrLike(user.uid, projectID, "like");
     },
-    onSuccess: (data) => {
-      // 지원 완료 후 프로필로 이동
-      alert(data.message);
+    onSuccess: (data, projectID) => {
       if (data.success) {
-        Navigate("/profile");
+        queryClient.invalidateQueries({
+          queryKey: ["project-detail", projectID],
+        });
+        return;
       }
     },
     onError: (err) => {
@@ -31,4 +31,4 @@ const useProjectApply = (): UseMutationResult<ApiResMessage, Error, string> => {
     },
   });
 };
-export default useProjectApply;
+export default useProjectLike;

--- a/src/features/projects/queries/useProjectUnLike.ts
+++ b/src/features/projects/queries/useProjectUnLike.ts
@@ -1,14 +1,17 @@
 import { useMutation, type UseMutationResult } from "@tanstack/react-query";
-import { useNavigate } from "react-router-dom";
 
-import { updateApplyOrLike } from "@features/projects/api/projectsApi";
+import { updateUnLike } from "@features/projects/api/projectsApi";
 
 import type { ApiResMessage } from "@entities/projects/types/firebase";
 
+import queryClient from "@shared/react-query/queryClient";
 import { useAuthStore } from "@shared/stores/authStore";
 
-const useProjectApply = (): UseMutationResult<ApiResMessage, Error, string> => {
-  const Navigate = useNavigate();
+const useProjectUnLike = (): UseMutationResult<
+  ApiResMessage,
+  Error,
+  string
+> => {
   const user = useAuthStore((state) => state.user);
 
   return useMutation({
@@ -16,13 +19,14 @@ const useProjectApply = (): UseMutationResult<ApiResMessage, Error, string> => {
       if (!user) {
         throw new Error("로그인을 해주세요.");
       }
-      return updateApplyOrLike(user.uid, projectID, "apply");
+      return updateUnLike(user.uid, projectID);
     },
-    onSuccess: (data) => {
-      // 지원 완료 후 프로필로 이동
-      alert(data.message);
+    onSuccess: (data, projectID) => {
       if (data.success) {
-        Navigate("/profile");
+        queryClient.invalidateQueries({
+          queryKey: ["project-detail", projectID],
+        });
+        return;
       }
     },
     onError: (err) => {
@@ -31,4 +35,4 @@ const useProjectApply = (): UseMutationResult<ApiResMessage, Error, string> => {
     },
   });
 };
-export default useProjectApply;
+export default useProjectUnLike;

--- a/src/features/projects/ui/ProjectLike.tsx
+++ b/src/features/projects/ui/ProjectLike.tsx
@@ -1,0 +1,77 @@
+import type { JSX } from "@emotion/react/jsx-runtime";
+import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
+import FavoriteOutlinedIcon from "@mui/icons-material/FavoriteOutlined";
+import ShareIcon from "@mui/icons-material/Share";
+import { Box, styled } from "@mui/material";
+import { useParams } from "react-router-dom";
+
+import useLike from "@features/projects/hook/useLike";
+
+import { getStatusClassname } from "@shared/libs/utils/projectDetail";
+import type { ProjectListRes } from "@shared/types/project";
+
+type ProjectLikeType = Pick<ProjectListRes, "status" | "likedUsers">;
+
+const ProjectLike = ({ values }: { values: ProjectLikeType }): JSX.Element => {
+  const { id } = useParams();
+  const { like, unlike, isLike } = useLike({
+    projectID: id || "",
+    likedUsers: values.likedUsers,
+  });
+
+  return (
+    <Box display="flex" alignItems="center" justifyContent="space-between">
+      <StatusBox className={getStatusClassname(values.status)}>
+        {values.status}
+      </StatusBox>
+
+      <Box display="flex">
+        <HeadIconBox>
+          {isLike ? (
+            <FavoriteOutlinedIcon color="error" onClick={unlike} />
+          ) : (
+            <FavoriteBorderIcon onClick={like} />
+          )}
+        </HeadIconBox>
+        <HeadIconBox>
+          <ShareIcon />
+        </HeadIconBox>
+      </Box>
+    </Box>
+  );
+};
+export default ProjectLike;
+
+const HeadIconBox = styled(Box)`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 3.5rem;
+  height: 3rem;
+  padding: 0.5rem 1rem;
+  margin-left: 10px;
+  border: 1px solid #dddddd;
+  border-radius: 4px;
+  transition: background-color 0.3s;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #f4f4f4;
+  }
+`;
+
+const StatusBox = styled("div")`
+  padding: 0.5rem 1.2rem;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.025em;
+  color: white;
+  border-radius: 50px;
+
+  &.ing {
+    background-color: black;
+  }
+  &.done {
+    background-color: ${({ theme }) => theme.palette.primary.main};
+  }
+`;

--- a/src/pages/project-detail/ui/ProjectDetailPage.tsx
+++ b/src/pages/project-detail/ui/ProjectDetailPage.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useParams } from "react-router-dom";
 
 import ProjectApplyForm from "@features/projects/ui/ProjectApplyForm";
 import ProjectDelete from "@features/projects/ui/ProjectDelete";
+import ProjectLike from "@features/projects/ui/ProjectLike";
 
 import useProjectsItem from "@entities/projects/queries/useProjectsItem";
 import ProjectApply from "@entities/projects/ui/post-info/ProjectApply";
@@ -18,6 +19,7 @@ import ProjectSchedule from "@entities/projects/ui/projects-detail/ProjectSchedu
 import TechStack from "@entities/projects/ui/projects-detail/TechStack";
 
 import { useAuthStore } from "@shared/stores/authStore";
+import type { RecruitmentStatus } from "@shared/types/project";
 
 const ProjectDetailPage = (): JSX.Element | null => {
   const { id } = useParams();
@@ -29,11 +31,15 @@ const ProjectDetailPage = (): JSX.Element | null => {
     isError,
   } = useProjectsItem({ id: id || null });
 
+  const projectLikeValues = {
+    status: (project?.status as RecruitmentStatus) || "모집중",
+    likedUsers: project?.likedUsers || [],
+  };
+
   const projectInfoValues = !project
     ? null
     : {
         title: project.title,
-        status: project.status,
         teamSize: project.teamSize,
         workflow: project.workflow,
         simpleInfo: project.simpleInfo,
@@ -85,6 +91,7 @@ const ProjectDetailPage = (): JSX.Element | null => {
       <CardContainer>
         <Box flex={3}>
           <CardBox>
+            <ProjectLike values={projectLikeValues} />
             <ProjectInfo values={projectInfoValues} />
           </CardBox>
           <CardBox>


### PR DESCRIPTION
## 개요
프로젝트 상세 조회 페이지 내에 좋아요, 좋아요 취소 기능을 추가하였습니다

## 변경 사항
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정

## 구현 내용
- 좋아요 / 좋아요 취소 관련 firebase api 추가
   - 지원하기 / 좋아요 기능은 동일한 컬렉션을 수정하므로 하나로 합쳐 재사용하였습니다. 
   - 좋아요 완료 후 querykey로 상세페이지 리랜더
   -  api 응답속도가 느려 ux측면에서 pending에 상관없이 먼저 랜더되도록 하였으며, 중복 호출을 방지하기 위해 pending 검사식을 넣었습니다.
- 기존 좋아요 버튼 ui가 entry 폴더에 합쳐져 있어 update기능을 수행하므로 feature 폴더로 분리하였습니다.

## 개발 후기 및 개선사항
### 이번 작업에서 배운 점
- (없다면 패스)

### 어려웠던 점 / 에로사항
- (없다면 패스)

### 다음에 개선하고 싶은 점
- 

### 팀원들과 공유하고 싶은 팁
- firebase 성능을 높이는 방법이 있을까요 ... (곰 곰)