### PR TITLE
refactor: login후 이동 redirect 재설정

### DIFF
--- a/src/app/routes/App.tsx
+++ b/src/app/routes/App.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 
 import AuthLayout from "@app/routes/AuthLayout";
 import MainLayout from "@app/routes/MainLayout";
+import PrivateRoute from "@app/routes/PrivateRoute";
 
 import { useAuthObserver } from "@shared/hooks/useAuthObserver";
 import LoadingSpinner from "@shared/ui/loading-spinner/LoadingSpinner";
@@ -40,12 +41,29 @@ function App(): JSX.Element {
 
           {/* 헤더 포함 레이아웃 (메인 페이지) */}
           <Route element={<MainLayout />}>
+            {/* 공개 페이지 */}
             <Route path="/" element={<HomePage />} />
-            <Route path="/profile" element={<UserProfilePage />} />
             <Route path="/project" element={<ProjectListPage />} />
-            <Route path="/project/insert" element={<ProjectInsertPage />} />
             <Route path="/project/:id" element={<ProjectDetailPage />} />
             <Route path="*" element={<NotFoundPage />} />
+
+            {/* 비공개 페이지 */}
+            <Route
+              path="/profile"
+              element={
+                <PrivateRoute>
+                  <UserProfilePage />
+                </PrivateRoute>
+              }
+            />
+            <Route
+              path="/project/insert"
+              element={
+                <PrivateRoute>
+                  <ProjectInsertPage />
+                </PrivateRoute>
+              }
+            />
           </Route>
         </Routes>
       </Suspense>

--- a/src/app/routes/PrivateRoute.tsx
+++ b/src/app/routes/PrivateRoute.tsx
@@ -1,0 +1,21 @@
+import React, { type JSX } from "react";
+import { Navigate, useLocation } from "react-router-dom";
+
+import { useAuthStore } from "@shared/stores/authStore";
+
+const PrivateRoute = ({
+  children,
+}: {
+  children: React.ReactNode;
+}): JSX.Element => {
+  const user = useAuthStore((state) => state.user);
+  const location = useLocation();
+
+  if (!user) {
+    return <Navigate to={`/login?redirect=${location.pathname}`} replace />;
+  }
+
+  return <>{children}</>;
+};
+
+export default PrivateRoute;

--- a/src/features/auth/hooks/useSocialLogin.ts
+++ b/src/features/auth/hooks/useSocialLogin.ts
@@ -4,7 +4,7 @@ import {
   getAdditionalUserInfo,
 } from "firebase/auth";
 import type { AuthProvider } from "firebase/auth";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 
 import { auth } from "@shared/firebase/firebase";
 
@@ -12,6 +12,8 @@ export const useSocialLogin = (): {
   socialLogin: (provider: AuthProvider) => Promise<void>;
 } => {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const redirect = searchParams.get("redirect") || "/";
 
   const socialLogin = async (provider: AuthProvider): Promise<void> => {
     try {
@@ -27,7 +29,7 @@ export const useSocialLogin = (): {
       if (isNewUser) {
         navigate("/signup");
       } else {
-        navigate("/");
+        navigate(redirect);
       }
     } catch (error: any) {
       console.error("소셜 로그인 실패: ", error);


### PR DESCRIPTION
## 개요
[ UX 개선사항 ]
로그인 로직이 완료되었음을 확인하고 진행하였습니다. 로그인 여부에 따라 공개 / 비공개 페이지를 Route 단에서 구분하고 redirect url을 설정하여 로그인 후 본래 접근하려했던 url로 이동할 수 있도록 ux를 개선하였습니다.
- ex) 비로그인으로 '/profile' 접속 -> 비로그인 이므로 '/login' 이동 -> 로그인 완료 -> '/profile' 이동
- 적용된 비공개 페이지: '/project', '/project/insert'

## 변경 사항
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정

## 구현 내용
- PrivateRoute.tsx 추가
   - 비공개 페이지의 경우, 로그인 여부에 따라 접속 url을 판별합니다.
   - 로그인 완료 후 이동될 redirect url은 url에 쿼리스트링으로 전달 되도록 하였습니다.

## 개발 후기 및 개선사항
### 이번 작업에서 배운 점
- (없다면 패스)

### 어려웠던 점 / 에로사항
- (없다면 패스)

### 다음에 개선하고 싶은 점
- (없다면 패스)

### 팀원들과 공유하고 싶은 팁
- (없다면 패스) 