### PR TITLE
refactor: 기존의 프로젝트 등록페이지 ui를 분리하였습니다

### DIFF
--- a/src/features/projects/hook/useProjectInsertForm.ts
+++ b/src/features/projects/hook/useProjectInsertForm.ts
@@ -1,4 +1,5 @@
 import { Timestamp } from "firebase/firestore";
+import { useState } from "react";
 
 import useProjectInsert from "@features/projects/queries/useProjectInsert";
 
@@ -11,19 +12,62 @@ import {
 import { ExpectedPeriod } from "@shared/types/schedule";
 import { UserExperience } from "@shared/types/user";
 
-const useProjectInsertForm = (): { submit: () => Promise<void> } => {
+// 이하 InitData 개선 예정
+type Setp1Type = Pick<
+  ProjectItemInsertReq,
+  "title" | "oneLineInfo" | "category" | "closedDate" | "simpleInfo"
+>;
+
+interface InsertFormResult {
+  form: {
+    step1: Setp1Type;
+  };
+  page: {
+    currentStep: number;
+    goPrev: () => void;
+    goNext: () => void;
+  };
+  submit: () => Promise<void>;
+}
+
+const useProjectInsertForm = (): InsertFormResult => {
   const { mutate: insertItem, isPending } = useProjectInsert();
 
+  const [currentStep, setCurrentStep] = useState(1);
+  // const [formStep1, setFormStep1] = useState<Setp1Type>(initForm1);
+
+  const handlePrev = (): void => setCurrentStep((prev) => prev - 1);
+  const handleNext = (): void => setCurrentStep((prev) => prev + 1);
+
   const submit = async (): Promise<void> => {
+    if (!window.confirm("등록을 완료 하시겠습니까?")) return;
     if (isPending) return;
     // form 검사 추가 바람
     insertItem(TestData);
   };
 
-  return { submit };
+  return {
+    form: {
+      step1: initForm1,
+    },
+    page: {
+      currentStep: currentStep,
+      goPrev: handlePrev,
+      goNext: handleNext,
+    },
+    submit,
+  };
 };
 
 export default useProjectInsertForm;
+
+const initForm1 = {
+  title: "",
+  oneLineInfo: "",
+  category: ProjectCategory.webDevelopment,
+  closedDate: Timestamp.now(),
+  simpleInfo: "",
+};
 
 // 테스트용 form 입니다.
 const TestData: ProjectItemInsertReq = {

--- a/src/features/projects/ui/project-insert/PageNaviBtn.tsx
+++ b/src/features/projects/ui/project-insert/PageNaviBtn.tsx
@@ -1,0 +1,48 @@
+import { Box, Button, styled } from "@mui/material";
+import type { JSX } from "react";
+
+const PageNaviBtn = ({
+  currentStep,
+  handlePrev,
+  handleNext,
+  handleSubmit, // type=submit 버튼이 노출될 때 submit이 실행되는 오류가 있어서 임시로 ..
+}: {
+  currentStep: number;
+  handlePrev: () => void;
+  handleNext: () => void;
+  handleSubmit: () => void;
+}): JSX.Element => {
+  return (
+    <Box display="flex" justifyContent="space-between" mt={4}>
+      {currentStep === 1 ? (
+        <div />
+      ) : (
+        <PrevBtn variant="outlined" onClick={handlePrev}>
+          이전 단계
+        </PrevBtn>
+      )}
+
+      {currentStep < 4 ? (
+        <Button variant="contained" onClick={handleNext}>
+          다음 단계 →
+        </Button>
+      ) : (
+        <Button onClick={handleSubmit} variant="contained">
+          프로젝트 등록하기
+        </Button>
+      )}
+    </Box>
+  );
+};
+
+export default PageNaviBtn;
+
+const PrevBtn = styled(Button)`
+  color: black;
+  background-color: white;
+  border: 1px solid #dddddd;
+
+  &:hover {
+    background-color: #f4f4f4;
+  }
+`;

--- a/src/features/projects/ui/project-insert/Step1.tsx
+++ b/src/features/projects/ui/project-insert/Step1.tsx
@@ -1,0 +1,76 @@
+import { Box, styled, useMediaQuery, useTheme } from "@mui/material";
+import type { JSX } from "react";
+
+import ProjectCategoryCard from "@entities/projects/ui/project-insert/ProjectCategoryCard";
+import ProjectDeadlineCard from "@entities/projects/ui/project-insert/ProjectDeadlineCard";
+import ProjectOneLineCard from "@entities/projects/ui/project-insert/ProjectOneLineCard";
+import ProjectSimpleDescCard from "@entities/projects/ui/project-insert/ProjectSimpleDescCard";
+import ProjectTitleCard from "@entities/projects/ui/project-insert/ProjectTitleCard";
+
+import { formatDate } from "@shared/libs/utils/projectDetail";
+import type { ProjectItemInsertReq } from "@shared/types/project";
+
+type SetpType = Pick<
+  ProjectItemInsertReq,
+  "title" | "oneLineInfo" | "category" | "closedDate" | "simpleInfo"
+>;
+
+const Step1 = ({ form }: { form: SetpType }): JSX.Element => {
+  const theme = useTheme();
+  const isMdDown = useMediaQuery(theme.breakpoints.down("md"));
+
+  const handleChange = (): void => {};
+
+  return (
+    <StepBox>
+      <ProjectTitleCard
+        value={form.title}
+        onChange={handleChange}
+        large
+        style={{ gridColumn: "span 1" }}
+      />
+      <ProjectOneLineCard
+        value={form.oneLineInfo}
+        onChange={handleChange}
+        large
+        style={{ gridColumn: "span 1" }}
+      />
+      {/* category의 type이 enum이라 콘솔에 경고가 뜹니다 */}
+      <ProjectCategoryCard
+        value={form.category}
+        onChange={handleChange}
+        large
+        style={{ gridColumn: "span 1" }}
+      />
+      <ProjectDeadlineCard
+        value={formatDate(form.closedDate)}
+        onChange={handleChange}
+        large
+        style={{ gridColumn: "span 1" }}
+      />
+      <ProjectSimpleDescCard
+        value={form.simpleInfo}
+        onChange={handleChange}
+        large
+        // ??
+        style={{ gridColumn: isMdDown ? "span 1" : "1 / -1" }}
+      />
+    </StepBox>
+  );
+};
+
+export default Step1;
+
+export const StepBox = styled(Box)(({ theme }) => ({
+  display: "grid",
+  gridTemplateColumns: "1fr", // 기본값(xs)
+
+  gap: theme.spacing(2), // 기본값(sm 이하)
+
+  marginBottom: 0,
+
+  [theme.breakpoints.up("md")]: {
+    gridTemplateColumns: "1fr 1fr",
+    gap: theme.spacing(4),
+  },
+}));

--- a/src/features/projects/ui/project-insert/Step2.tsx
+++ b/src/features/projects/ui/project-insert/Step2.tsx
@@ -1,0 +1,20 @@
+import { Box, styled } from "@mui/material";
+import type { JSX } from "react";
+
+const Step2 = (): JSX.Element => {
+  return <StepBox>Step2</StepBox>;
+};
+
+export default Step2;
+
+export const StepBox = styled(Box)(({ theme }) => ({
+  display: "grid",
+  gridTemplateColumns: "1fr", // 기본값(xs)
+  gap: theme.spacing(2), // 기본값(sm 이하)
+  marginBottom: 0,
+
+  [theme.breakpoints.up("md")]: {
+    gridTemplateColumns: "1fr 1fr",
+    gap: theme.spacing(4),
+  },
+}));

--- a/src/features/projects/ui/project-insert/Step3.tsx
+++ b/src/features/projects/ui/project-insert/Step3.tsx
@@ -1,0 +1,20 @@
+import { Box, styled } from "@mui/material";
+import type { JSX } from "react";
+
+const Step3 = (): JSX.Element => {
+  return <StepBox>Step3</StepBox>;
+};
+
+export default Step3;
+
+export const StepBox = styled(Box)(({ theme }) => ({
+  display: "grid",
+  gridTemplateColumns: "1fr", // 기본값(xs)
+  gap: theme.spacing(2), // 기본값(sm 이하)
+  marginBottom: 0,
+
+  [theme.breakpoints.up("md")]: {
+    gridTemplateColumns: "1fr 1fr",
+    gap: theme.spacing(4),
+  },
+}));

--- a/src/features/projects/ui/project-insert/Step4.tsx
+++ b/src/features/projects/ui/project-insert/Step4.tsx
@@ -1,0 +1,20 @@
+import { Box, styled } from "@mui/material";
+import type { JSX } from "react";
+
+const Step4 = (): JSX.Element => {
+  return <StepBox>Step4</StepBox>;
+};
+
+export default Step4;
+
+export const StepBox = styled(Box)(({ theme }) => ({
+  display: "grid",
+  gridTemplateColumns: "1fr", // 기본값(xs)
+  gap: theme.spacing(2), // 기본값(sm 이하)
+  marginBottom: 0,
+
+  [theme.breakpoints.up("md")]: {
+    gridTemplateColumns: "1fr 1fr",
+    gap: theme.spacing(4),
+  },
+}));

--- a/src/pages/project-insert/ui/HoneyTipBox.tsx
+++ b/src/pages/project-insert/ui/HoneyTipBox.tsx
@@ -1,0 +1,77 @@
+import { Box, styled } from "@mui/material";
+import type { JSX } from "react";
+
+import TextWithEmoji from "@shared/ui/project-insert/TextWithEmoji";
+
+// Typography에 fontSize={number}은 적용되지 않으므로 삭제하엿습니다.
+// 스타일이 반복되어 사용되고 있기에 공통 컴포넌트로 만들어 재사용하였습니다.
+
+const HoneyTipBox = (): JSX.Element => {
+  return (
+    <TipBox>
+      <TextWithEmoji
+        emoji="💡"
+        emoji_label="lightbulb"
+        mainText="꿀팁 모음집"
+      />
+
+      <Box
+        display="flex"
+        flexWrap="wrap"
+        gap={4}
+        mt={3}
+        flexDirection={{ xs: "column", sm: "row" }}
+      >
+        <Box flex={1}>
+          <TextWithEmoji
+            emoji="🎯"
+            emoji_label="dart"
+            mainText="구체적인 계획을 세우세요"
+            subText="일정과 역할이 명확할수록 좋은 팀원을 만날 수 있어요"
+          />
+          <TextWithEmoji
+            emoji="🤝"
+            emoji_label="handshake"
+            mainText="초보자도 환영해요"
+            subText="경험보다 열정이 더 중요할 때가 많아요"
+          />
+        </Box>
+        <Box flex={1}>
+          <TextWithEmoji
+            emoji="💬"
+            emoji_label="chat"
+            mainText="소통 방식 미리 정하기"
+            subText="언제, 어떻게 만날지 미리 정해두면 좋아요"
+          />
+          <TextWithEmoji
+            emoji="🎉"
+            emoji_label="fun"
+            mainText="재미있게 표현하기"
+            subText="딱딱한 설명보다 재미있는 설명이 더 매력적이에요"
+          />
+        </Box>
+      </Box>
+    </TipBox>
+  );
+};
+
+export default HoneyTipBox;
+
+// 해당 Box는 부모의 MainContainer 밖으로 넘어가지 않으므로 MaxWidth, marginX 설정을 제거하였습니다.
+const TipBox = styled(Box)(({ theme }) => ({
+  marginTop: theme.spacing(6), // default spacing이 8px ... 라고 하네요
+  backgroundColor: "#fffbe6",
+  border: "1.5px solid #ffe6a0",
+  borderRadius: theme.spacing(1),
+  padding: theme.spacing(3),
+  paddingLeft: theme.spacing(1),
+  paddingRight: theme.spacing(1),
+  [theme.breakpoints.up("sm")]: {
+    paddingLeft: theme.spacing(2),
+    paddingRight: theme.spacing(2),
+  },
+  [theme.breakpoints.up("md")]: {
+    paddingLeft: theme.spacing(3),
+    paddingRight: theme.spacing(3),
+  },
+}));

--- a/src/pages/project-insert/ui/ProjectInsertPage.tsx
+++ b/src/pages/project-insert/ui/ProjectInsertPage.tsx
@@ -1,322 +1,48 @@
 import type { CSSObject } from "@emotion/react";
-import { Box, Button, Typography, Container } from "@mui/material";
+import { Container } from "@mui/material";
 import type { ContainerProps } from "@mui/material/Container";
-import { styled, useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import useMediaQuery from "@mui/material/useMediaQuery";
-import { useState, type FormEvent } from "react";
+import { styled } from "@mui/material/styles";
 import type { JSX } from "react";
 
+import HoneyTipBox from "@pages/project-insert/ui/HoneyTipBox";
+import StepBox from "@pages/project-insert/ui/StepBox";
+import TopTitle from "@pages/project-insert/ui/TopTitle";
+
 import useProjectInsert from "@features/projects/hook/useProjectInsertForm";
-
-import ProjectCategoryCard from "@entities/projects/ui/project-insert/ProjectCategoryCard";
-import ProjectDeadlineCard from "@entities/projects/ui/project-insert/ProjectDeadlineCard";
-import ProjectOneLineCard from "@entities/projects/ui/project-insert/ProjectOneLineCard";
-import ProjectSimpleDescCard from "@entities/projects/ui/project-insert/ProjectSimpleDescCard";
-import ProjectTitleCard from "@entities/projects/ui/project-insert/ProjectTitleCard";
-
-const steps = [
-  { id: 1, title: "기본 정보" },
-  { id: 2, title: "팀 구성" },
-  { id: 3, title: "프로젝트 계획" },
-  { id: 4, title: "모집 조건" },
-];
-
-const initialForm = {
-  title: "",
-  subtitle: "",
-  category: "",
-  description: "",
-  deadline: "",
-};
-
-const PRIMARY = "#2563EB";
-const PRIMARY_DARK = "#1d4ed8";
+import PageNaviBtn from "@features/projects/ui/project-insert/PageNaviBtn";
+import Step1 from "@features/projects/ui/project-insert/Step1";
+import Step2 from "@features/projects/ui/project-insert/Step2";
+import Step3 from "@features/projects/ui/project-insert/Step3";
+import Step4 from "@features/projects/ui/project-insert/Step4";
 
 const ProjectInsertPage = (): JSX.Element => {
-  const { submit } = useProjectInsert();
-  const [currentStep, setCurrentStep] = useState(1);
-  const [form, setForm] = useState(initialForm);
-  const theme = useTheme();
-  const isSmDown = useMediaQuery(theme.breakpoints.down("sm"));
-  const isMdDown = useMediaQuery(theme.breakpoints.down("md"));
-
-  const handleChange = (e: any): void => {
-    const { name, value } = e.target;
-    setForm((prev) => ({ ...prev, [name]: value }));
-  };
-
-  const handleNext = (): void => setCurrentStep((prev) => prev + 1);
-
-  const handleSubmit = (e: FormEvent): void => {
-    e.preventDefault();
-    submit();
-    alert("프로젝트 등록!");
-  };
+  const { form, page, submit } = useProjectInsert();
 
   return (
-    <MainContainer
-      sx={{
-        px: { xs: 1, sm: 2, md: 3 },
-        py: { xs: 4, sm: 6, md: 8 },
-      }}
-    >
+    <MainContainer>
       {/* 상단 타이틀/설명 */}
-      <Box maxWidth={700} mx="auto" pb={2} textAlign="center">
-        <Typography variant="h3" fontWeight={800} mb={1} color="#222">
-          같이 할 사람 구해요! 🚀
-        </Typography>
-        <Typography variant="h6" color="#555" mb={0.5}>
-          멋진 아이디어가 있다면 팀원을 모집해보세요
-        </Typography>
-        <Typography fontSize={15} color="#888">
-          혼자서는 힘들어도 함께라면 뭐든 할 수 있어요!
-        </Typography>
-      </Box>
+      <TopTitle />
 
       {/* 스텝바 */}
-      <Box display="flex" justifyContent="center" gap={4} mb={5}>
-        {steps.map((step, idx) => (
-          <Box key={step.id} display="flex" alignItems="center">
-            <Box
-              sx={{
-                width: 38,
-                height: 38,
-                borderRadius: "50%",
-                background: currentStep === step.id ? PRIMARY : "#e0e7ef",
-                color: currentStep === step.id ? "#fff" : "#888",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                fontWeight: 700,
-                fontSize: 18,
-                border: `2px solid ${currentStep === step.id ? PRIMARY : "#e0e7ef"}`,
-              }}
-            >
-              {step.id}
-            </Box>
-            <Typography
-              sx={{
-                ml: 1,
-                mr: 1,
-                fontWeight: currentStep === step.id ? 700 : 500,
-                color: currentStep === step.id ? PRIMARY : "#888",
-                fontSize: 16,
-              }}
-            >
-              {step.title}
-            </Typography>
-            {idx < steps.length - 1 && (
-              <Box color="#bbb" fontSize={22}>
-                →
-              </Box>
-            )}
-          </Box>
-        ))}
-      </Box>
+      <StepBox currentStep={page.currentStep} />
 
-      <Box component="form" onSubmit={handleSubmit} maxWidth={1500} mx="auto">
-        {/* 1단계: 기본 정보 */}
-        {currentStep === 1 && (
-          <>
-            <div
-              style={{
-                display: "grid",
-                gridTemplateColumns: isMdDown ? "1fr" : "1fr 1fr",
-                gap: theme.spacing(isSmDown ? 2 : 4),
-                marginBottom: 0,
-              }}
-            >
-              <ProjectTitleCard
-                value={form.title}
-                onChange={handleChange}
-                large
-                style={{ gridColumn: "span 1" }}
-              />
-              <ProjectOneLineCard
-                value={form.subtitle}
-                onChange={handleChange}
-                large
-                style={{ gridColumn: "span 1" }}
-              />
-              <ProjectCategoryCard
-                value={form.category}
-                onChange={handleChange}
-                large
-                style={{ gridColumn: "span 1" }}
-              />
-              <ProjectDeadlineCard
-                value={form.deadline}
-                onChange={handleChange}
-                large
-                style={{ gridColumn: "span 1" }}
-              />
-              <ProjectSimpleDescCard
-                value={form.description}
-                onChange={handleChange}
-                large
-                style={{ gridColumn: isMdDown ? "span 1" : "1 / -1" }}
-              />
-            </div>
-          </>
-        )}
+      {/* Step별 컴포넌트 */}
+      {page.currentStep === 1 && <Step1 form={form.step1} />}
+      {page.currentStep === 2 && <Step2 />}
+      {page.currentStep === 3 && <Step3 />}
+      {page.currentStep === 4 && <Step4 />}
 
-        {/* 네비게이션 버튼 */}
-        <Box display="flex" justifyContent="flex-end" gap={2} mt={4}>
-          <Button
-            variant="outlined"
-            sx={{
-              color: PRIMARY,
-              borderColor: PRIMARY,
-              fontWeight: 700,
-              px: 3,
-            }}
-          >
-            임시 저장
-          </Button>
-          {currentStep < steps.length ? (
-            <Button
-              variant="contained"
-              sx={{
-                background: PRIMARY,
-                fontWeight: 700,
-                px: 4,
-                "&:hover": { background: PRIMARY_DARK },
-              }}
-              onClick={handleNext}
-              disabled={
-                !(
-                  form.title &&
-                  form.subtitle &&
-                  form.category &&
-                  form.description &&
-                  form.deadline
-                )
-              }
-            >
-              다음 단계 →
-            </Button>
-          ) : (
-            <Button
-              type="submit"
-              variant="contained"
-              sx={{
-                background: PRIMARY,
-                fontWeight: 700,
-                px: 4,
-                "&:hover": { background: PRIMARY_DARK },
-              }}
-            >
-              프로젝트 등록하기
-            </Button>
-          )}
-        </Box>
-      </Box>
+      {/* 네비게이션 버튼 */}
+      <PageNaviBtn
+        currentStep={page.currentStep}
+        handlePrev={page.goPrev}
+        handleNext={page.goNext}
+        handleSubmit={submit}
+      />
 
       {/* 꿀팁 모음집 */}
-      <Box
-        maxWidth={1500}
-        mx="auto"
-        mt={6}
-        bgcolor="#fffbe6"
-        border="1.5px solid #ffe6a0"
-        borderRadius={1}
-        p={3}
-        px={{ xs: 1, sm: 2, md: 3 }}
-      >
-        <Typography
-          fontWeight={700}
-          fontSize={22}
-          mb={3}
-          display="flex"
-          alignItems="center"
-          gap={1}
-        >
-          <span role="img" aria-label="lightbulb">
-            💡
-          </span>{" "}
-          꿀팁 모음집
-        </Typography>
-        <Box
-          display="flex"
-          flexWrap="wrap"
-          gap={4}
-          flexDirection={{ xs: "column", sm: "row" }}
-        >
-          <Box flex={1} minWidth={220}>
-            <Typography
-              fontWeight={700}
-              fontSize={18}
-              mb={0.5}
-              color="#222"
-              display="flex"
-              alignItems="center"
-              gap={1}
-            >
-              <span role="img" aria-label="target">
-                🎯
-              </span>{" "}
-              구체적인 계획을 세우세요
-            </Typography>
-            <Typography fontSize={16} color="#555" mb={2}>
-              일정과 역할이 명확할수록 좋은 팀원을 만날 수 있어요
-            </Typography>
-            <Typography
-              fontWeight={700}
-              fontSize={18}
-              mb={0.5}
-              color="#222"
-              display="flex"
-              alignItems="center"
-              gap={1}
-            >
-              <span role="img" aria-label="handshake">
-                🤝
-              </span>{" "}
-              초보자도 환영해요
-            </Typography>
-            <Typography fontSize={16} color="#555">
-              경험보다 열정이 더 중요할 때가 많아요
-            </Typography>
-          </Box>
-          <Box flex={1} minWidth={220}>
-            <Typography
-              fontWeight={700}
-              fontSize={18}
-              mb={0.5}
-              color="#222"
-              display="flex"
-              alignItems="center"
-              gap={1}
-            >
-              <span role="img" aria-label="chat">
-                💬
-              </span>{" "}
-              소통 방식 미리 정하기
-            </Typography>
-            <Typography fontSize={16} color="#555" mb={2}>
-              언제, 어떻게 만날지 미리 정해두면 좋아요
-            </Typography>
-            <Typography
-              fontWeight={700}
-              fontSize={18}
-              mb={0.5}
-              color="#222"
-              display="flex"
-              alignItems="center"
-              gap={1}
-            >
-              <span role="img" aria-label="party">
-                🎉
-              </span>{" "}
-              재미있게 표현하기
-            </Typography>
-            <Typography fontSize={16} color="#555">
-              딱딱한 설명보다 재미있는 설명이 더 매력적이에요
-            </Typography>
-          </Box>
-        </Box>
-      </Box>
+      <HoneyTipBox />
     </MainContainer>
   );
 };
@@ -327,6 +53,7 @@ const MainContainer = styled(Container)<ContainerProps>(
   ({ theme }: { theme: Theme }): CSSObject => ({
     flexGrow: 1,
     minHeight: "100vh",
+    padding: "3rem",
     backgroundColor: theme.palette.background.default,
   })
 );

--- a/src/pages/project-insert/ui/StepBox.tsx
+++ b/src/pages/project-insert/ui/StepBox.tsx
@@ -1,0 +1,64 @@
+import { Box, styled, Typography } from "@mui/material";
+import type { JSX } from "react";
+
+// 현재는 setps를 객체로 된 배열로 관리하지만 단순한 스타일의 반복이니
+// JS로 탐색 후 뿌려주는 것 보단 공통 스타일 컴포넌트를 생성하여 구성하는 것이 더 좋아보입니다!
+// 추후에 여유가 될 때 리팩토링 해주시면 좋을거같습니다 ~
+const steps = [
+  { id: 1, title: "기본 정보" },
+  { id: 2, title: "팀 구성" },
+  { id: 3, title: "프로젝트 계획" },
+  { id: 4, title: "모집 조건" },
+];
+
+// 스타일이 많아 코드 가독성 + 추후 재사용성을 고려하여 styled 컴포넌트로 빼내었습니다.
+// 이렇게 하면 굳이 PRIMARY를 변수로 선언하지 않아도 theme에 저장된 색상을 불러올 수 있씁니다!
+// key는 배열의 idx로 설정해 두었으며(가장 간단)
+// '->'를 표시하기위한 삼항연산자도 간결하게 수정하였습니다
+// 여기 또한 Typography에 fontSize={number} 설정은 적용되지 않으므로 삭제하엿습니다
+
+const StepBox = ({ currentStep }: { currentStep: number }): JSX.Element => {
+  return (
+    <Box display="flex" justifyContent="center" gap={4} mb={5}>
+      {steps.map((step, idx) => (
+        <Box key={idx} display="flex" alignItems="center">
+          <StepNumber active={currentStep === step.id}>{step.id}</StepNumber>
+          <StepName active={currentStep === step.id}>{step.title}</StepName>
+          {idx !== 3 && (
+            <Box color="#bbb" fontSize={22}>
+              →
+            </Box>
+          )}
+        </Box>
+      ))}
+    </Box>
+  );
+};
+
+export default StepBox;
+
+const StepNumber = styled(Box, {
+  //  active prop은 DOM에 전달되지 않도록 shouldForwardProp 필수
+  shouldForwardProp: (prop) => prop !== "active",
+})<{ active: boolean }>(({ active, theme }) => ({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  width: 38,
+  height: 38,
+  fontSize: 18,
+  fontWeight: 700,
+  color: active ? "#fff" : "#888",
+  background: active ? theme.palette.primary.main : "#e0e7ef",
+  borderRadius: "50%",
+  border: `2px solid ${active ? theme.palette.primary.main : "#e0e7ef"}`,
+}));
+
+const StepName = styled(Typography, {
+  shouldForwardProp: (prop) => prop !== "active",
+})<{ active: boolean }>(({ active, theme }) => ({
+  marginLeft: theme.spacing(1),
+  marginRight: theme.spacing(1),
+  fontWeight: active ? 700 : 500,
+  color: active ? theme.palette.primary.main : "#888",
+}));

--- a/src/pages/project-insert/ui/TopTitle.tsx
+++ b/src/pages/project-insert/ui/TopTitle.tsx
@@ -1,0 +1,22 @@
+import { Box, Typography } from "@mui/material";
+import type { JSX } from "react";
+
+// Box: maxWidth={700} mx="auto" 설정이 불필요하여 삭제히였습니다.
+// Typography 엔 fontSize 설정이 적용되지 않아 삭제하였습니다.
+const TopTitle = (): JSX.Element => {
+  return (
+    <Box pb={2} textAlign="center">
+      <Typography variant="h3" fontWeight={800} mb={1} color="#222">
+        같이 할 사람 구해요! 🚀
+      </Typography>
+      <Typography variant="h6" color="#555" mb={0.5}>
+        멋진 아이디어가 있다면 팀원을 모집해보세요
+      </Typography>
+      <Typography color="#888">
+        혼자서는 힘들어도 함께라면 뭐든 할 수 있어요!
+      </Typography>
+    </Box>
+  );
+};
+
+export default TopTitle;

--- a/src/shared/ui/project-insert/TextWithEmoji.tsx
+++ b/src/shared/ui/project-insert/TextWithEmoji.tsx
@@ -1,0 +1,39 @@
+import { Typography } from "@mui/material";
+import type { JSX } from "react";
+
+const TextWithEmoji = ({
+  emoji,
+  emoji_label,
+  mainText,
+  subText,
+}: {
+  emoji: string;
+  emoji_label: string;
+  mainText: string;
+  subText?: string;
+}): JSX.Element => {
+  return (
+    <>
+      <Typography
+        variant="h5"
+        mb={0.5}
+        color="#222"
+        display="flex"
+        alignItems="center"
+        gap={1}
+      >
+        <span role="img" aria-label={emoji_label}>
+          {emoji}
+        </span>{" "}
+        {mainText}
+      </Typography>
+      {subText && (
+        <Typography color="#555" mb={2}>
+          {subText}
+        </Typography>
+      )}
+    </>
+  );
+};
+
+export default TextWithEmoji;


### PR DESCRIPTION
## 개요
민영님이 작업해주신 프로젝트 등록페이지의 ui를 컴포넌트화 하여 분리하였습니다.
styled는 불필요한 선언을 제외하고 거의 건들지 않고 분리만 했습니다!

## 변경 사항
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정

## 구현 내용
- 등록페이지 ui 컴포넌트 분리
   - 각각 TopTitle, StepBox, HoneyTipBox, PageNaviBtn, Step1, Step2,Step3,Step4 로 기능별로 분리하였습니다
- currentStep, form등 조작할 내부 변수들은 커스텀 훅으로 분리하였습니다.
- submit 함수가 중복 선언이 되어 훅에서 하나로 합쳤습니다. 

## 개발 후기 및 개선사항
### 이번 작업에서 배운 점
- mui에서 스타일 컴포넌트에 props를 전해줄 때 shouldForwardProp를 넣어줘야한다는 것을 새롭게 알았습니다.(실제 DOM요소에 쓰이는 값이 아니라는 것을 명시하여 전달을 제어)

### 어려웠던 점 / 에로사항
- (없다면 패스)

### 다음에 개선하고 싶은 점
- 스탭별 form관리를 어떻게 하는게 제일 편할까욤 흠 

### 팀원들과 공유하고 싶은 팁
- (없다면 패스) 