### PR TITLE
feat: users에 내가 등록한 프로젝트 리스트 추가

### DIFF
--- a/src/features/projects/api/userAPi.ts
+++ b/src/features/projects/api/userAPi.ts
@@ -1,0 +1,33 @@
+import { arrayUnion, doc, updateDoc } from "firebase/firestore";
+
+import type { ApiResMessage } from "@entities/projects/types/firebase";
+
+import { db } from "@shared/firebase/firebase";
+
+/**
+ * 내가 등록한 프로젝트 등록
+ * users - myProjects에 ProjectID 넣기
+ *  */
+export const updateUserMyProject = async (
+  uid: string,
+  projectID: string
+): Promise<ApiResMessage> => {
+  const usersRef = doc(db, "users", uid);
+
+  try {
+    await updateDoc(usersRef, {
+      myProjects에: arrayUnion(projectID),
+    });
+
+    return {
+      success: true,
+      message: "",
+    };
+  } catch (err) {
+    console.log(err);
+    return {
+      success: false,
+      message: "profile update실패. 동작이 반복 될 시 관리자에게 문의 주세요.",
+    };
+  }
+};

--- a/src/features/projects/hook/useProjectInsertForm.ts
+++ b/src/features/projects/hook/useProjectInsertForm.ts
@@ -3,6 +3,8 @@ import { useState } from "react";
 
 import useProjectInsert from "@features/projects/queries/useProjectInsert";
 
+import { useUserProfile } from "@shared/queries/useUserProfile";
+import { useAuthStore } from "@shared/stores/authStore";
 import {
   ProjectCategory,
   RecruitmentStatus,
@@ -10,7 +12,7 @@ import {
   type ProjectItemInsertReq,
 } from "@shared/types/project";
 import { ExpectedPeriod } from "@shared/types/schedule";
-import { UserExperience } from "@shared/types/user";
+import { type User } from "@shared/types/user";
 
 // 이하 InitData 개선 예정
 type Setp1Type = Pick<
@@ -41,18 +43,14 @@ interface InsertFormResult {
 }
 
 const useProjectInsertForm = (): InsertFormResult => {
-  const { mutate: insertItem, isPending } = useProjectInsert();
+  const user = useAuthStore((state) => state.user);
+  const { data: userProfile } = useUserProfile(user?.uid || "");
+  const { mutate: insertProject, isPending } = useProjectInsert();
 
   const [currentStep, setCurrentStep] = useState(1);
-  // Step1 상태
   // const [formStep1, setFormStep1] = useState<Setp1Type>(initForm1);
-  // Step2 상태
-  const [formStep2, setFormStep2] = useState<Step2Type>({
-    teamSize: 0,
-    expectedPeriod: "",
-    techStack: [],
-    positions: [],
-  });
+  const [formStep2, setFormStep2] = useState<Step2Type>(initForm2);
+
   const handleChangeStep2 = (field: keyof Step2Type, value: any): void => {
     setFormStep2((prev) => ({ ...prev, [field]: value }));
   };
@@ -67,15 +65,19 @@ const useProjectInsertForm = (): InsertFormResult => {
   };
 
   const submit = async (): Promise<void> => {
+    if (!userProfile) return;
     if (!window.confirm("등록을 완료 하시겠습니까?")) return;
     if (isPending) return;
-    // form 검사 추가 바람
-    insertItem(TestData);
-  };
 
-  // lint에러를 피하기 위한...
-  // 추후에 step3, step4 훅 만들 때 가져다 쓰시라고 미리 만들어놨습니다!
-  console.log(initForm2, initForm3, initForm4);
+    // lint에러를 피하기 위한...
+    // 추후에 step3, step4 훅 만들 때 가져다 쓰시라고 미리 만들어놨습니다!
+    console.log(initForm2, initForm3, initForm4);
+
+    // form 검사 추가 바람
+
+    // projects에 insert
+    insertProject(TestData(userProfile));
+  };
 
   return {
     form: {
@@ -120,14 +122,14 @@ const initForm4 = {
 };
 
 // 테스트용 form 입니다.
-const TestData: ProjectItemInsertReq = {
+const TestData = (user: User): ProjectItemInsertReq => ({
   projectOwner: {
-    id: "user1234",
-    name: "홍길동",
-    userRole: "frontend",
-    email: "test@test.com",
-    experience: UserExperience.junior,
-    avatar: "https://via.placeholder.com/150",
+    id: user.id,
+    name: user.name,
+    userRole: user.userRole,
+    email: user.email,
+    experience: user.experience,
+    avatar: user.avatar,
   },
   applicants: [],
   status: RecruitmentStatus.recruiting,
@@ -180,4 +182,4 @@ const TestData: ProjectItemInsertReq = {
   likedUsers: [],
   category: ProjectCategory.webDevelopment,
   closedDate: Timestamp.now(),
-};
+});

--- a/src/features/projects/queries/useProjectInsert.ts
+++ b/src/features/projects/queries/useProjectInsert.ts
@@ -2,6 +2,7 @@ import { useMutation, type UseMutationResult } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 
 import { insertProjectItem } from "@features/projects/api/projectsApi";
+import { updateUserMyProject } from "@features/projects/api/userAPi";
 
 import type { ApiResMessage } from "@entities/projects/types/firebase";
 
@@ -23,11 +24,17 @@ const useProjectInsert = (): UseMutationResult<
       }
       return insertProjectItem(projectItem);
     },
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       // 게시글 등록 후 본인 게시글로 이동
       if (data.success && data.id) {
-        alert("게시글이 등록 되었습니다.");
-        Navigate(`/project/${data.id}`);
+        try {
+          await updateUserMyProject(user?.uid || "", data.id);
+
+          alert("게시글이 등록 되었습니다.");
+          Navigate(`/project/${data.id}`);
+        } catch (err) {
+          console.log("users 업데이트 실패: ", err);
+        }
       }
     },
     onError: (err) => {

--- a/src/shared/api/userApi.ts
+++ b/src/shared/api/userApi.ts
@@ -1,0 +1,18 @@
+import { doc, setDoc, getDoc } from "firebase/firestore";
+
+import { db } from "@shared/firebase/firebase";
+import type { User } from "@shared/types/user";
+
+export const saveUser = async (uid: string, userInfo: User): Promise<void> => {
+  const userDoc = doc(db, "users", uid);
+  await setDoc(userDoc, userInfo);
+};
+
+export const getUser = async (uid: string): Promise<User | null> => {
+  const userDoc = doc(db, "users", uid);
+  const userSnap = await getDoc(userDoc);
+  if (userSnap.exists()) {
+    return userSnap.data() as User;
+  }
+  return null;
+};

--- a/src/shared/queries/useUserProfile.ts
+++ b/src/shared/queries/useUserProfile.ts
@@ -1,0 +1,12 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+
+import { getUser } from "@shared/api/userApi";
+import type { User } from "@shared/types/user";
+
+export function useUserProfile(uid: string): UseQueryResult<User | null> {
+  return useQuery<User | null>({
+    queryKey: ["userProfile", uid],
+    queryFn: () => getUser(uid),
+    enabled: !!uid, // uid가 있을 때만 쿼리 실행
+  });
+}

--- a/src/shared/types/user.ts
+++ b/src/shared/types/user.ts
@@ -8,6 +8,7 @@ export interface User {
   likeProjects?: string[]; // 좋아요 누른 프로젝트
   appliedProjects?: string[]; // 지원한 프로젝트
   introduceMyself?: string; // 자기소개
+  myProjects?: string[]; // 내가 등록한 프로젝트
 }
 
 export type UserRole = "frontend" | "backend" | "fullstack" | "designer" | "pm";


### PR DESCRIPTION
## 개요
프로젝트 등록 시 로그인한 유저의 프로필에 '내가 등록한 프로젝트'(myProjects) 필드가 추가됩니다.
및 프로젝트 등록 시 유저 프로필을 조회하는 로직이 필수로 들어가므로 기존 getUser 파일을 share로 옮겼습니다.

## 변경 사항
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 구현 내용
- User 인터페이스에 myProjects 옵셔널로 추가
- updateUserMyProject api 추가
- 프로젝트 등록 시 projectOwner의 등록자 프로필 삽입

## 개발 후기 및 개선사항
### 이번 작업에서 배운 점
- (없다면 패스)

### 어려웠던 점 / 에로사항
- updateUserMyProject를 useMutation로 만들어 프로잭트 등록(useMutation) 이후 연결 시켜보려고 했는데 잘 안되어서 ... useProjectInsert success 에서 그냥 api 연결 시켜버렸습니다만 ,, 좋은 방법이 더 있을까요 ? 

### 다음에 개선하고 싶은 점
- (없다면 패스)

### 팀원들과 공유하고 싶은 팁
- (없다면 패스) 