### PR TITLE
style: 등록페이지 반응형 작업 완료

### DIFF
--- a/src/entities/projects/ui/project-insert/ProjectCategoryCard.tsx
+++ b/src/entities/projects/ui/project-insert/ProjectCategoryCard.tsx
@@ -32,22 +32,42 @@ const ProjectCategoryCard = ({
         <Select
           value={value || ""}
           onChange={onChange}
-          size={large ? "medium" : "small"}
+          size="small"
           displayEmpty
           sx={{
-            fontSize: large
-              ? theme.typography.h5.fontSize
-              : theme.typography.body1.fontSize,
-            fontFamily: theme.typography.fontFamily,
-            height: 40,
-            border: `1px solid ${theme.palette.divider}`,
-            boxSizing: "border-box",
-            padding: large ? theme.spacing(2.2) : theme.spacing(1.7),
+            height: { xs: 40, sm: 48 },
+            "& .MuiOutlinedInput-root": {
+              height: { xs: "40px !important", sm: "48px !important" },
+              fontSize: {
+                xs: "16px",
+                sm: "17px",
+                md: "18px",
+              },
+              fontFamily: theme.typography.fontFamily,
+              background: "none",
+              border: "none",
+              "&:hover .MuiOutlinedInput-notchedOutline": {
+                borderColor: theme.palette.text.primary,
+              },
+              "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+                borderColor: theme.palette.primary.main,
+                borderWidth: "2px",
+              },
+            },
             "& .MuiSelect-select": {
-              height: "40px",
+              padding: large ? theme.spacing(2.2) : theme.spacing(1.7),
+              height: "auto !important",
+              minHeight: "unset !important",
               display: "flex",
               alignItems: "center",
-              padding: 0,
+              fontSize: {
+                xs: "16px",
+                sm: "16px",
+                md: "17px",
+              },
+              "&[aria-expanded='false']": {
+                color: value ? "inherit" : "#999",
+              },
             },
           }}
         >

--- a/src/entities/projects/ui/project-insert/ProjectDeadlineCard.tsx
+++ b/src/entities/projects/ui/project-insert/ProjectDeadlineCard.tsx
@@ -1,3 +1,5 @@
+import { TextField } from "@mui/material";
+import { useTheme } from "@mui/material/styles";
 import type { ChangeEvent, CSSProperties, JSX } from "react";
 
 import SimpleFormCard from "@shared/ui/project-insert/SimpleFormCard";
@@ -15,6 +17,8 @@ const ProjectDeadlineCard = ({
   large,
   style,
 }: ProjectDeadlineCardProps): JSX.Element => {
+  const theme = useTheme();
+
   return (
     <SimpleFormCard
       title="모집 마감일"
@@ -23,22 +27,41 @@ const ProjectDeadlineCard = ({
       large={large}
       style={style}
     >
-      <input
+      <TextField
         type="date"
         name="deadline"
         value={value}
         onChange={onChange}
-        style={{
-          width: "100%",
-          padding: large ? 18 : 14,
-          borderRadius: 8,
-          border: "1px solid #e0e0e0",
-          fontSize: 16,
-          marginBottom: 8,
-          fontFamily: "inherit",
-          height: 40,
-          boxSizing: "border-box",
-          background: "inherit",
+        fullWidth
+        variant="outlined"
+        size="small"
+        slotProps={{
+          inputLabel: {
+            shrink: true,
+          },
+        }}
+        sx={{
+          "& .MuiOutlinedInput-root": {
+            height: { xs: 40, sm: 48 },
+            fontSize: {
+              xs: "16px",
+              sm: "17px",
+              md: "18px",
+            },
+            fontFamily: theme.typography.fontFamily,
+            background: "none",
+            border: "none",
+            "&:hover .MuiOutlinedInput-notchedOutline": {
+              borderColor: theme.palette.text.primary,
+            },
+            "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+              borderColor: theme.palette.primary.main,
+              borderWidth: "2px",
+            },
+          },
+          "& .MuiOutlinedInput-input": {
+            padding: large ? theme.spacing(2.2) : theme.spacing(1.7),
+          },
         }}
         required
       />

--- a/src/entities/projects/ui/project-insert/ProjectDetailDescriptionCard.tsx
+++ b/src/entities/projects/ui/project-insert/ProjectDetailDescriptionCard.tsx
@@ -1,5 +1,4 @@
 import { TextField } from "@mui/material";
-import { useMediaQuery } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import type { ChangeEvent, CSSProperties, JSX } from "react";
 
@@ -19,7 +18,6 @@ const ProjectDetailDescriptionCard = ({
   style,
 }: ProjectDetailDescriptionCardProps): JSX.Element => {
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
 
   const handleChange = (e: ChangeEvent<HTMLTextAreaElement>): void => {
     onChange(e.target.value);
@@ -47,18 +45,18 @@ AI 기술을 활용하여 개인별 학습 패턴을 분석하고, 최적화된 
 ## 🚀 기대 효과
 - 개인화된 학습으로 학습 효율성 30% 향상
 - 학습 동기 부여 및 지속성 증대`}
-        multiline // 여러 줄 입력 가능
+        multiline
         minRows={large ? 12 : 8}
         maxRows={large ? 20 : 15}
         fullWidth
         variant="outlined"
         sx={{
           "& .MuiOutlinedInput-root": {
-            fontSize: isMobile
-              ? theme.typography.body2.fontSize
-              : large
-                ? theme.typography.h5.fontSize
-                : theme.typography.body1.fontSize,
+            fontSize: {
+              xs: "15px",
+              sm: "16px",
+              md: "17px",
+            },
             fontFamily: "monospace",
             lineHeight: 1.6,
             padding: 0,
@@ -73,6 +71,19 @@ AI 기술을 활용하여 개인별 학습 패턴을 분석하고, 최적화된 
           "& .MuiOutlinedInput-input": {
             padding: large ? theme.spacing(2.5) : theme.spacing(2),
             resize: "vertical",
+            fontSize: {
+              xs: "15px",
+              sm: "16px",
+              md: "17px",
+            },
+            "&::placeholder": {
+              fontSize: {
+                xs: "15px",
+                sm: "16px",
+                md: "17px",
+              },
+              color: "#999",
+            },
           },
         }}
       />

--- a/src/entities/projects/ui/project-insert/ProjectExpectedPeriodCard.tsx
+++ b/src/entities/projects/ui/project-insert/ProjectExpectedPeriodCard.tsx
@@ -32,22 +32,42 @@ export default function ProjectScheduleCard({
         <Select<ExpectedPeriod>
           value={value || ("" as ExpectedPeriod)}
           onChange={onChange}
-          size={large ? "medium" : "small"}
+          size="small"
           displayEmpty
           sx={{
-            fontSize: {
-              xs: large ? "14px" : "14px",
-              sm: large ? "15px" : "15px",
-              md: large ? "16px" : "16px",
+            height: { xs: 40, sm: 48 },
+            "& .MuiOutlinedInput-root": {
+              height: { xs: "40px !important", sm: "48px !important" },
+              fontSize: {
+                xs: "16px",
+                sm: "17px",
+                md: "18px",
+              },
+              fontFamily: theme.typography.fontFamily,
+              background: "none",
+              border: "none",
+              "&:hover .MuiOutlinedInput-notchedOutline": {
+                borderColor: theme.palette.text.primary,
+              },
+              "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+                borderColor: theme.palette.primary.main,
+                borderWidth: "2px",
+              },
             },
-            fontFamily: theme.typography.fontFamily,
-            padding: large ? theme.spacing(2.2) : theme.spacing(1.7),
-            height: 40,
             "& .MuiSelect-select": {
-              height: "40px",
+              padding: large ? theme.spacing(2.2) : theme.spacing(1.7),
+              height: "auto !important",
+              minHeight: "unset !important",
               display: "flex",
               alignItems: "center",
-              padding: 0,
+              fontSize: {
+                xs: "16px",
+                sm: "17px",
+                md: "18px",
+              },
+              "&[aria-expanded='false']": {
+                color: value ? "inherit" : "#999",
+              },
             },
           }}
         >

--- a/src/entities/projects/ui/project-insert/ProjectOneLineCard.tsx
+++ b/src/entities/projects/ui/project-insert/ProjectOneLineCard.tsx
@@ -39,18 +39,18 @@ const ProjectOneLineCard = ({
         sx={{
           "& .MuiOutlinedInput-root": {
             height: 40,
-            fontSize: large
-              ? theme.typography.h5.fontSize
-              : theme.typography.body1.fontSize,
+            fontSize: {
+              xs: "16px",
+              sm: "17px",
+              md: "18px",
+            },
             fontFamily: theme.typography.fontFamily,
             background: "none",
             border: "none",
 
-            // 호버 시 테두리 검정색
             "&:hover .MuiOutlinedInput-notchedOutline": {
               borderColor: theme.palette.text.primary,
             },
-            // 포커스 시 테두리 primary 색상
             "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
               borderColor: theme.palette.primary.main,
               borderWidth: "2px",
@@ -60,9 +60,9 @@ const ProjectOneLineCard = ({
             padding: large ? theme.spacing(2.2) : theme.spacing(1.7),
             "&::placeholder": {
               fontSize: {
-                xs: "14px",
-                sm: "15px",
-                md: "16px",
+                xs: "16px",
+                sm: "17px",
+                md: "18px",
               },
               color: "#999",
             },

--- a/src/entities/projects/ui/project-insert/ProjectPreferentialCard.tsx
+++ b/src/entities/projects/ui/project-insert/ProjectPreferentialCard.tsx
@@ -1,15 +1,7 @@
 import AddIcon from "@mui/icons-material/Add";
 import { Box, Button } from "@mui/material";
-import { useMediaQuery } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
-import type {
-  ChangeEvent,
-  CSSProperties,
-  JSX,
-  FocusEvent,
-  MouseEvent,
-  KeyboardEvent,
-} from "react";
+import type { ChangeEvent, CSSProperties, JSX, KeyboardEvent } from "react";
 import { useState } from "react";
 
 import SimpleFormCard from "@shared/ui/project-insert/SimpleFormCard";
@@ -28,7 +20,6 @@ const ProjectPreferentialCard = ({
   style,
 }: ProjectPreferentialCardProps): JSX.Element => {
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
   const [newPreferential, setNewPreferential] = useState("");
 
   const addPreferential = (): void => {
@@ -59,7 +50,8 @@ const ProjectPreferentialCard = ({
     >
       {/* 입력 + 추가 버튼 */}
       <Box display="flex" gap={1} mb={2}>
-        <input
+        <Box
+          component="input"
           type="text"
           value={newPreferential}
           onChange={(e: ChangeEvent<HTMLInputElement>) =>
@@ -67,40 +59,42 @@ const ProjectPreferentialCard = ({
           }
           onKeyUp={handleKeyPress}
           placeholder="예: AWS, Docker, 스타트업 경험..."
-          style={{
+          sx={{
             flex: 1,
-            height: 40,
-            borderRadius: theme.shape.borderRadius,
-            border: `1px solid ${theme.palette.divider}`,
-            fontSize: isMobile
-              ? theme.typography.body2.fontSize
-              : large
-                ? theme.typography.h5.fontSize
-                : theme.typography.body1.fontSize,
+            height: { xs: "40px !important", sm: "48px !important" },
+            borderRadius: "8px",
+            border: `1px solid #c9c9c9`,
+            fontSize: {
+              xs: "16px",
+              sm: "17px",
+              md: "18px",
+            },
             fontFamily: theme.typography.fontFamily,
-            background: theme.palette.background.paper,
-            padding: large ? theme.spacing(2.2) : theme.spacing(1.7),
+            background: "none",
+            padding: large ? theme.spacing(1.5) : theme.spacing(1),
             boxSizing: "border-box",
             outline: "none",
             transition: "border-color 0.2s ease-in-out",
-          }}
-          onFocus={(e) => {
-            e.target.style.borderColor = theme.palette.primary.main;
-            e.target.style.borderWidth = "2px";
-          }}
-          onBlur={(e: FocusEvent<HTMLInputElement>) => {
-            e.currentTarget.style.borderColor = theme.palette.divider;
-            e.currentTarget.style.borderWidth = "1px";
-          }}
-          onMouseEnter={(e: MouseEvent<HTMLInputElement>) => {
-            if (e.currentTarget !== document.activeElement) {
-              e.currentTarget.style.borderColor = "#000000";
-            }
-          }}
-          onMouseLeave={(e: MouseEvent<HTMLInputElement>) => {
-            if (e.currentTarget !== document.activeElement) {
-              e.currentTarget.style.borderColor = theme.palette.divider;
-            }
+            lineHeight: "normal",
+            minHeight: "unset",
+
+            "&::placeholder": {
+              fontSize: {
+                xs: "16px",
+                sm: "17px",
+                md: "18px",
+              },
+              color: "#999",
+            },
+
+            "&:focus": {
+              borderColor: theme.palette.primary.main,
+              borderWidth: "2px",
+            },
+
+            "&:hover:not(:focus)": {
+              borderColor: theme.palette.text.primary,
+            },
           }}
         />
         <Button
@@ -109,7 +103,7 @@ const ProjectPreferentialCard = ({
           disabled={!newPreferential.trim()}
           sx={{
             minWidth: 48,
-            height: 46,
+            height: { xs: "40px !important", sm: "48px !important" },
             backgroundColor: "#2563EB",
             "&:hover": { backgroundColor: "#1d4ed8" },
           }}
@@ -132,7 +126,11 @@ const ProjectPreferentialCard = ({
                 py: 1,
                 backgroundColor: theme.palette.grey[100],
                 borderRadius: "999px",
-                fontSize: "1.5rem",
+                fontSize: {
+                  xs: "16px",
+                  sm: "17px",
+                  md: "18px",
+                },
                 color: theme.palette.text.primary,
               }}
             >
@@ -148,7 +146,11 @@ const ProjectPreferentialCard = ({
                   color: theme.palette.text.primary,
                   backgroundColor: "transparent",
                   cursor: "pointer",
-                  fontSize: "18px",
+                  fontSize: {
+                    xs: "16px",
+                    sm: "17px",
+                    md: "18px",
+                  },
                   display: "flex",
                   alignItems: "center",
                   justifyContent: "center",

--- a/src/entities/projects/ui/project-insert/ProjectRequirementsCard.tsx
+++ b/src/entities/projects/ui/project-insert/ProjectRequirementsCard.tsx
@@ -1,7 +1,6 @@
 import AddIcon from "@mui/icons-material/Add";
 import DeleteIcon from "@mui/icons-material/Delete";
 import { Box, IconButton, TextField, Button } from "@mui/material";
-import { useMediaQuery } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import type { ChangeEvent, CSSProperties, JSX } from "react";
 
@@ -21,7 +20,6 @@ const ProjectRequirementsCard = ({
   style,
 }: ProjectRequirementsCardProps): JSX.Element => {
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
 
   const displayValue = value;
 
@@ -73,12 +71,12 @@ const ProjectRequirementsCard = ({
               size="small"
               sx={{
                 "& .MuiOutlinedInput-root": {
-                  height: 40,
-                  fontSize: isMobile
-                    ? theme.typography.body2.fontSize
-                    : large
-                      ? theme.typography.h5.fontSize
-                      : theme.typography.body1.fontSize,
+                  height: { xs: 36, sm: 48 },
+                  fontSize: {
+                    xs: "16px",
+                    sm: "17px",
+                    md: "18px",
+                  },
                   fontFamily: theme.typography.fontFamily,
                   background: "none",
                   border: "none",
@@ -94,7 +92,15 @@ const ProjectRequirementsCard = ({
                   },
                 },
                 "& .MuiOutlinedInput-input": {
-                  padding: large ? theme.spacing(2.2) : theme.spacing(1.7),
+                  padding: large ? theme.spacing(1.5) : theme.spacing(1),
+                  "&::placeholder": {
+                    fontSize: {
+                      xs: "16px",
+                      sm: "17px",
+                      md: "18px",
+                    },
+                    color: "#999",
+                  },
                 },
               }}
             />

--- a/src/entities/projects/ui/project-insert/ProjectSimpleDescCard.tsx
+++ b/src/entities/projects/ui/project-insert/ProjectSimpleDescCard.tsx
@@ -1,4 +1,5 @@
-import { TextField, useTheme } from "@mui/material";
+import { TextField } from "@mui/material";
+import { useTheme } from "@mui/material/styles";
 import type { ChangeEvent, CSSProperties, JSX } from "react";
 
 import SimpleFormCard from "@shared/ui/project-insert/SimpleFormCard";
@@ -38,10 +39,15 @@ const ProjectSimpleDescCard = ({
         size="small"
         sx={{
           "& .MuiOutlinedInput-root": {
-            fontSize: 16,
-            fontFamily: "inherit",
+            fontSize: {
+              xs: "16px",
+              sm: "17px",
+              md: "18px",
+            },
+            fontFamily: theme.typography.fontFamily,
             background: "none",
-
+            border: "none",
+            minHeight: { md: 46, sm: 43, xs: 40 },
             "&:hover .MuiOutlinedInput-notchedOutline": {
               borderColor: theme.palette.text.primary,
             },
@@ -51,12 +57,13 @@ const ProjectSimpleDescCard = ({
             },
           },
           "& .MuiOutlinedInput-input": {
-            padding: large ? theme.spacing(2.2) : theme.spacing(1.7),
+            padding: large ? theme.spacing(1.5) : theme.spacing(1.2),
+            minHeight: { md: "46px", sm: "43px", xs: "40px" },
             "&::placeholder": {
               fontSize: {
-                xs: "14px",
-                sm: "15px",
-                md: "16px",
+                xs: "16px",
+                sm: "17px",
+                md: "18px",
               },
               color: "#999",
             },

--- a/src/entities/projects/ui/project-insert/ProjectTeamSizeCard.tsx
+++ b/src/entities/projects/ui/project-insert/ProjectTeamSizeCard.tsx
@@ -31,23 +31,42 @@ const ProjectTeamSizeCard = ({
         <Select<string>
           value={value ? value.toString() : ""}
           onChange={onChange}
-          size={large ? "medium" : "small"}
+          size="small"
           displayEmpty
           sx={{
-            fontSize: {
-              xs: large ? "14px" : "14px",
-              sm: large ? "15px" : "15px",
-              md: large ? "16px" : "16px",
+            height: { xs: 40, sm: 48 },
+            "& .MuiOutlinedInput-root": {
+              height: { xs: "40px !important", sm: "48px !important" },
+              fontSize: {
+                xs: "16px",
+                sm: "17px",
+                md: "18px",
+              },
+              fontFamily: theme.typography.fontFamily,
+              background: "none",
+              border: "none",
+              "&:hover .MuiOutlinedInput-notchedOutline": {
+                borderColor: theme.palette.text.primary,
+              },
+              "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+                borderColor: theme.palette.primary.main,
+                borderWidth: "2px",
+              },
             },
-            fontFamily: theme.typography.fontFamily,
-            padding: large ? theme.spacing(2.2) : theme.spacing(1.7),
-
-            height: 40,
             "& .MuiSelect-select": {
-              height: "40px",
+              padding: large ? theme.spacing(2.2) : theme.spacing(1.7),
+              height: "auto !important",
+              minHeight: "unset !important",
               display: "flex",
               alignItems: "center",
-              padding: 0,
+              fontSize: {
+                xs: "16px",
+                sm: "17px",
+                md: "18px",
+              },
+              "&[aria-expanded='false']": {
+                color: value ? "inherit" : "#999",
+              },
             },
           }}
         >

--- a/src/entities/projects/ui/project-insert/ProjectTechStackCard.tsx
+++ b/src/entities/projects/ui/project-insert/ProjectTechStackCard.tsx
@@ -61,26 +61,28 @@ const ProjectTechStackCard = ({
           placeholder="React, Python, Figma... 뭐든 좋아요!"
           sx={{
             flex: 1,
-            height: 40,
+            height: { xs: "40px !important", sm: "48px !important" },
             borderRadius: "8px",
-            border: `1px solid ${theme.palette.divider}`,
+            border: `1px solid #c9c9c9`,
             fontSize: {
-              xs: "14px",
-              sm: "15px",
-              md: "16px",
+              xs: "16px",
+              sm: "17px",
+              md: "18px",
             },
             fontFamily: theme.typography.fontFamily,
-            background: theme.palette.background.paper,
-            padding: large ? theme.spacing(2.2) : theme.spacing(1.7),
+            background: "none",
+            padding: large ? theme.spacing(1.5) : theme.spacing(1),
             boxSizing: "border-box",
             outline: "none",
             transition: "border-color 0.2s ease-in-out",
+            lineHeight: "normal",
+            minHeight: "unset",
 
             "&::placeholder": {
               fontSize: {
-                xs: "14px", // 모바일
-                sm: "15px", // 태블릿
-                md: "16px", // 데스크톱
+                xs: "16px",
+                sm: "17px",
+                md: "18px",
               },
               color: "#999",
             },
@@ -91,7 +93,7 @@ const ProjectTechStackCard = ({
             },
 
             "&:hover:not(:focus)": {
-              borderColor: "#000000",
+              borderColor: theme.palette.text.primary,
             },
           }}
         />
@@ -101,7 +103,7 @@ const ProjectTechStackCard = ({
           disabled={!newTech.trim()}
           sx={{
             minWidth: 48,
-            height: 46,
+            height: { xs: "40px !important", sm: "48px !important" },
             backgroundColor: "#2563EB",
             "&:hover": { backgroundColor: "#1d4ed8" },
           }}
@@ -125,9 +127,9 @@ const ProjectTechStackCard = ({
                 backgroundColor: theme.palette.grey[100],
                 borderRadius: 2,
                 fontSize: {
-                  xs: "14px",
-                  sm: "15px",
-                  md: "16px",
+                  xs: "16px",
+                  sm: "17px",
+                  md: "18px",
                 },
                 color: theme.palette.text.primary,
               }}

--- a/src/entities/projects/ui/project-insert/ProjectTitleCard.tsx
+++ b/src/entities/projects/ui/project-insert/ProjectTitleCard.tsx
@@ -39,17 +39,17 @@ const ProjectTitleCard = ({
         sx={{
           "& .MuiOutlinedInput-root": {
             height: 40,
-            fontSize: large
-              ? theme.typography.h5.fontSize
-              : theme.typography.body1.fontSize,
+            fontSize: {
+              xs: "16px",
+              sm: "17px",
+              md: "18px",
+            },
             fontFamily: theme.typography.fontFamily,
             background: "none",
             border: "none",
-            // 호버 시 테두리 검정색
             "&:hover .MuiOutlinedInput-notchedOutline": {
               borderColor: theme.palette.text.primary,
             },
-            // 포커스 시 테두리 primary 색상
             "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
               borderColor: theme.palette.primary.main,
               borderWidth: "2px",
@@ -59,9 +59,9 @@ const ProjectTitleCard = ({
             padding: large ? theme.spacing(2.2) : theme.spacing(1.7),
             "&::placeholder": {
               fontSize: {
-                xs: "14px",
-                sm: "15px",
-                md: "16px",
+                xs: "16px",
+                sm: "17px",
+                md: "18px",
               },
               color: "#999",
             },

--- a/src/entities/projects/ui/project-insert/ProjectWorkflowCard.tsx
+++ b/src/entities/projects/ui/project-insert/ProjectWorkflowCard.tsx
@@ -1,6 +1,5 @@
 import type { SelectChangeEvent } from "@mui/material";
 import { FormControl, Select, MenuItem } from "@mui/material";
-import { useMediaQuery } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import type { CSSProperties, JSX } from "react";
 
@@ -44,7 +43,6 @@ export default function ProjectWorkflowCard({
   style,
 }: ProjectWorkflowCardProps): JSX.Element {
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
 
   const handleChange = (event: SelectChangeEvent<Workflow>): void => {
     onChange(event.target.value as Workflow);
@@ -61,23 +59,42 @@ export default function ProjectWorkflowCard({
         <Select<Workflow>
           value={value || ("" as Workflow)}
           onChange={handleChange}
-          size={large ? "medium" : "small"}
+          size="small"
           displayEmpty
           sx={{
-            fontSize: isMobile
-              ? theme.typography.body2.fontSize
-              : large
-                ? theme.typography.h5.fontSize
-                : theme.typography.body1.fontSize,
-            fontFamily: theme.typography.fontFamily,
-            padding: large ? theme.spacing(2.2) : theme.spacing(1.7),
-
-            height: 40,
+            height: { xs: 40, sm: 48 },
+            "& .MuiOutlinedInput-root": {
+              height: { xs: "36px !important", sm: "48px !important" },
+              fontSize: {
+                xs: "16px",
+                sm: "17px",
+                md: "18px",
+              },
+              fontFamily: theme.typography.fontFamily,
+              background: "none",
+              border: "none",
+              "&:hover .MuiOutlinedInput-notchedOutline": {
+                borderColor: theme.palette.text.primary,
+              },
+              "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+                borderColor: theme.palette.primary.main,
+                borderWidth: "2px",
+              },
+            },
             "& .MuiSelect-select": {
-              height: "40px",
+              padding: large ? theme.spacing(1.5) : theme.spacing(1),
+              height: "auto !important",
+              minHeight: "unset !important",
               display: "flex",
               alignItems: "center",
-              padding: 0,
+              fontSize: {
+                xs: "16px",
+                sm: "17px",
+                md: "18px",
+              },
+              "&[aria-expanded='false']": {
+                color: value ? "inherit" : "#999",
+              },
             },
           }}
         >


### PR DESCRIPTION
## 개요
프로젝트 생성 폼의 모든 카드 컴포넌트들의 디자인 시스템을 통일하고 반응형 스타일을 적용하여 일관된 사용자 경험을 제공합니다.

## 변경 사항
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정

## 구현 내용
- **반응형 폰트사이즈 통일**: 모든 입력 필드에 xs: 16px, sm: 17px, md: 18px 적용
- **반응형 높이 통일**: 모바일(xs) 36px, 태블릿 이상(sm~) 48px로 일관된 높이 적용

## 개발 후기 및 개선사항
### 이번 작업에서 배운 점
- MUI Select와 TextField 간의 스타일 통일을 위해서는 `MuiOutlinedInput-root` 래퍼 사용이 필요함

### 어려웠던 점 / 에로사항
- Select 컴포넌트의 높이가 예상과 다르게 적용되어 `lineHeight: "normal"`, `minHeight: "unset"` 등 추가 속성 필요
- 네이티브 input 요소에서 MUI 스타일 시스템을 적용하기 위한 구조 변경 필요

### 다음에 개선하고 싶은 점
- (없다면 패스)

### 팀원들과 공유하고 싶은 팁
- (없다면 패스) 